### PR TITLE
MPI aware logging support

### DIFF
--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -199,7 +199,7 @@ class LoadFilesFromParams(pipeline.TaskBase):
         # Fetch and remove the first item in the list
         file_ = self.files.pop(0)
 
-        print "Loading file %s" % file_
+        self.log.info("Loading file %s" % file_)
 
         cont = memh5.BasicCont.from_file(file_, distributed=True)
 

--- a/draco/core/misc.py
+++ b/draco/core/misc.py
@@ -95,15 +95,13 @@ class ApplyGain(task.SingleTask):
         inverse_gain_arr = tools.invert_no_zero(gain_arr)
 
         # Apply gains to visibility matrix
-        if mpiutil.rank0:
-            print "Applying inverse gain." if self.inverse else "Applying gain."
+        self.log.info("Applying inverse gain." if self.inverse else "Applying gain.")
         gvis = inverse_gain_arr if self.inverse else gain_arr
         tools.apply_gain(tstream.vis[:], gvis, out=tstream.vis[:])
 
         # Apply gains to the weights
         if self.update_weight:
-            if mpiutil.rank0:
-                print "Applying gain to weight."
+            self.log.info("Applying gain to weight.")
             gweight = np.abs(gain_arr if self.inverse else inverse_gain_arr)**2
             tools.apply_gain(tstream.weight[:], gweight, out=tstream.weight[:])
 

--- a/test/pipe_config.yaml
+++ b/test/pipe_config.yaml
@@ -10,6 +10,9 @@ cluster:
 
 pipeline:
     tasks:
+
+        -   type:       draco.core.task.SetMPILogging
+
         -   type:       draco.core.io.LoadBeamTransfer
             out:        [tel, bt]
             params:


### PR DESCRIPTION
Initial support for MPI aware logging on pipeline tasks.

All `SingleTask` instances now have a `log` property returning a `logging.Logger` that can be used for logging messages. They also add information about the MPI process (rank and size) to the log record which can be displayed in the formatted message, and used for filtering.

There's also an `MPILogFilter` which can filter messages differentially based on the rank, in this case allowing us to accept messages with lower priorities on rank=0. By default rank=0 logs at the `logging.INFO` level and other ranks only at the `logging.WARN` level.

At the moment to enable the filtering and formatting aspects you need to call the `SetMPILogging` task, though in the long run I would like to expand the configurability of the logging in caput to enable this to be configured there (`logging.dictConfig` seems to be a very flexible way of setting up custom formatters, filters etc.)

With all this done, the recommended way for people to output useful messages in the pipeline is to use `self.log` with an appropriate priority, and to not restrict the output to any particular rank (that should be handled by filters).

@ssiegelx @kiyo-masui any comments appreciated.