### PR TITLE
Power spectrum estimation and foreground filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. This
+project adheres to [Semantic Versioning](http://semver.org/), with the exception
+that I'm using PEP440 to denote pre-releases.
+
+## [0.2.0] - 2017-06-24
+
+### Added
+
+- MPI aware logging functionality for tasks.
+- Support for table like data containers.
+- Routines for delay spectrum estimation and filtering
+- KL based foreground filtering
+- Quadratic power spectrum estimation
+
+### Fixes
+
+- Added a missing routine `_ensure_list`.
+
+
+## [0.1.0] - 2016-08-11
+
+### Added
+
+- Initial version of `draco` importing code from the CHIME pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ that I'm using PEP440 to denote pre-releases.
 
 ### Added
 
-- MPI aware logging functionality for tasks.
-- Support for table like data containers.
+- MPI aware logging functionality for tasks
+- Support for table like data containers
 - Routines for delay spectrum estimation and filtering
 - KL based foreground filtering
+- SVD based foreground filtering
 - Quadratic power spectrum estimation
+- Task for setting weights based on the radiometer expectation
+- Baseline masking task
+- Support for reading `ProductManager` instances (from `driftscan`) and updated
+  tasks to allow using them in place of `BeamTransfer` or `TransitTelescope`
+  instances as task arguments.
 
 ### Fixes
 

--- a/draco/__init__.py
+++ b/draco/__init__.py
@@ -1,2 +1,2 @@
 # Specify version in Semantic style (with PEP 440 pre-release specification)
-__version__ = '0.1.0.b1'
+__version__ = '0.2.0'

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -7,7 +7,7 @@ import scipy.stats as st
 
 from caput import mpiarray, config
 
-from ..core import containers, task
+from ..core import containers, task, io
 
 
 class DelayFilter(task.SingleTask):
@@ -95,7 +95,7 @@ class DelaySpectrumEstimator(task.SingleTask):
         ----------
         telescope : TransitTelescope
         """
-        self.telescope = telescope
+        self.telescope = io.get_telescope(telescope)
 
     def process(self, ss):
         """Estimate the delay spectrum.

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -1,0 +1,496 @@
+"""Delay space spectrum estimation and filtering.
+"""
+
+import numpy as np
+import scipy.linalg as la
+import scipy.stats as st
+
+from caput import mpiarray, config
+
+from ..core import containers, task
+
+
+class DelayFilter(task.SingleTask):
+    """Remove delays less than a given threshold.
+
+    Attributes
+    ----------
+    delay_cut : float
+        Delay value to filter at in seconds.
+    """
+
+    delay_cut = config.Property(proptype=float, default=0.1)
+
+    update_weight = config.Property(proptype=bool, default=False)
+
+    def process(self, ss):
+        """Filter out delays from a SiderealStream or TimeStream.
+
+        Parameters
+        ----------
+        ss : containers.SiderealStream
+            Data to filter.
+
+        Returns
+        -------
+        ss_filt : containers.SiderealStream
+            Filtered dataset.
+        """
+
+        if self.update_weight:
+            raise NotImplemented("Weight updating is not implemented.")
+
+        ss.redistribute('prod')
+
+        freq = ss.freq['centre']
+
+        for lbi, bi in ss.vis[:].enumerate(axis=1):
+
+            freq_weight = np.median(ss.weight[:, bi], axis=1)
+
+            NF = null_delay_filter(freq, self.delay_cut, freq_weight)
+
+            ss.vis[:, bi] = np.dot(NF, ss.vis[:, bi])
+
+        return ss
+
+
+class DelaySpectrumEstimator(task.SingleTask):
+    """Calculate the delay spectrum of a Sidereal/TimeStream for instrumental Stokes I.
+
+    The spectrum is calculated by Gibbs sampling. However, at the moment only
+    the final sample is used to calculate the spectrum.
+
+    Attributes
+    ----------
+    nsamp : int, optional
+        The number of Gibbs samples to draw.
+    freq_zero : float, optional
+        The physical frequency (in MHz) of the *zero* channel. That is the DC
+        channel coming out of the F-engine. If not specified, use the first
+        frequency channel of the stream.
+    freq_spacing : float, optional
+        The spacing between the underlying channels (in MHz). This is conjugate
+        to the length of a frame of time samples that is transformed. If not
+        set, then use the smallest gap found between channels in the dataset.
+    nfreq : int, optional
+        The number of frequency channels in the full set produced by the
+        F-engine. If not set, assume the last included frequency is the last of
+        the full set (or is the penultimate if `skip_nyquist` is set).
+    skip_nyquist : bool, optional
+        Whether the Nyquist frequency is included in the data. This is `True` by
+        default to align with the output of CASPER PFBs.
+    """
+
+    nsamp = config.Property(proptype=int, default=20)
+    freq_zero = config.Property(proptype=float, default=None)
+    freq_spacing = config.Property(proptype=float, default=None)
+    nfreq = config.Property(proptype=int, default=None)
+    skip_nyquist = config.Property(proptype=bool, default=True)
+
+    def setup(self, telescope):
+        """Set the telescope needed to generate Stokes I.
+
+        Parameters
+        ----------
+        telescope : TransitTelescope
+        """
+        self.telescope = telescope
+
+    def process(self, ss):
+        """Estimate the delay spectrum.
+
+        Parameters
+        ----------
+        ss : SiderealStream or TimeStream
+
+        Returns
+        -------
+        dspec : DelaySpectrum
+        """
+
+        tel = self.telescope
+
+        ss.redistribute('time')
+
+        # Construct the Stokes I vis
+        vis_I, vis_weight, baselines = stokes_I(ss, tel)
+
+        # ==== Figure out the frequency structure and delay values ====
+        if self.freq_zero is None:
+            self.freq_zero = ss.freq['centre'][0]
+
+        if self.freq_spacing is None:
+            self.freq_spacing = np.abs(np.diff(ss.freq['centre'])).min()
+
+        channel_ind = (np.abs(ss.freq['centre'] - self.freq_zero) /
+                       self.freq_spacing).astype(np.int)
+
+        if self.nfreq is None:
+            self.nfreq = channel_ind[-1] + 1
+
+            if self.skip_nyquist:
+                self.nfreq += 1
+
+        # Assume each transformed frame was an even number of samples long
+        ndelay = 2 * (self.nfreq - 1)
+        delays = np.fft.fftshift(np.fft.fftfreq(ndelay, d=self.freq_spacing))  # in us
+
+        # Initialise the spectrum container
+        delay_spec = containers.DelaySpectrum(baseline=baselines, delay=delays)
+        delay_spec.spectrum[:] = 0.0
+
+        initial_S = np.ones_like(delays) * 1e5
+
+        # Iterate over all baselines and use the Gibbs sampler to estimate the spectrum
+        for lbi, bi in delay_spec.spectrum[:].enumerate(axis=0):
+
+            self.log.debug("Delay transforming baseline %i/%i",
+                           bi, len(baselines))
+
+            data = vis_I[lbi].view(np.ndarray).T
+            weight = vis_weight[lbi].view(np.ndarray)
+            weight = np.median(weight, axis=1)
+
+            if (data == 0.0).all():
+                continue
+
+            spec = delay_spectrum_gibbs(data, ndelay, weight, initial_S,
+                                        fsel=channel_ind, niter=self.nsamp)
+
+            # Take an average over the last half of the delay spectrum samples
+            # (presuming that removes the burn-in)
+            spec_av = np.median(spec[-(self.nsamp / 2):], axis=0)
+            delay_spec.spectrum[bi] = np.fft.fftshift(spec_av)
+
+        return delay_spec
+
+
+def stokes_I(sstream, tel):
+    """Extract instrumental Stokes I from a time/sidereal stream.
+
+    Parameters
+    ----------
+    sstream : containers.SiderealStream, container.TimeStream
+        Stream of correlation data.
+    tel : TransitTelescope
+        Instance describing the telescope.
+
+    Returns
+    -------
+    vis_I : mpiarray.MPIArray[nbase, nfreq, ntime]
+        The instrumental Stokes I visibilities.
+    vis_weight : mpiarray.MPIArray[nbase, nfreq, ntime]
+        The weights for each visibility
+    baselines : np.ndarray[nbase, 2]
+    """
+
+    # ==== Unpack into Stokes I
+    ubase, uinv, ucount = np.unique(
+        tel.baselines[:, 0] + 1.0J * tel.baselines[:, 1],
+        return_inverse=True, return_counts=True
+    )
+    ubase = ubase.view(np.float64).reshape(-1, 2)
+    nbase = ubase.shape[0]
+
+    vis_shape = (nbase, sstream.vis.local_shape[0], sstream.vis.local_shape[2])
+    vis_I = np.zeros(vis_shape, dtype=np.complex64)
+    vis_weight = np.zeros(vis_shape, dtype=np.float32)
+
+    # Iterate over products to construct the Stokes I vis
+    # TODO: this should be updated when driftscan gains a concept of polarisation
+    for ii, ui in enumerate(uinv):
+
+        # Skip if not all polarisations were included
+        if ucount[ui] < 4:
+            continue
+
+        fi, fj = tel.uniquepairs[ii]
+        bi, bj = tel.beamclass[fi], tel.beamclass[fj]
+
+        upi = tel.feedmap[fi, fj]
+
+        if upi == -1:
+            continue
+
+        if bi == bj:
+            vis_I[ui] += sstream.vis[:, ii]
+            vis_weight[ui] += sstream.weight[:, ii]
+
+    vis_I = mpiarray.MPIArray.wrap(vis_I, axis=1, comm=sstream.comm)
+    vis_I = vis_I.redistribute(axis=0)
+    vis_weight = mpiarray.MPIArray.wrap(
+        vis_weight, axis=1, comm=sstream.comm
+    ).redistribute(axis=0)
+
+    return vis_I, vis_weight, ubase
+
+
+def window_generalised(x, window='nuttall'):
+    """A generalised high-order window at arbitrary locations.
+
+    Parameters
+    ----------
+    x : np.ndarray[n]
+        Location to evaluate at. Must be in the range 0 to 1.
+    window : one of {'nuttall', 'blackman_nuttall', 'blackman_harris'}
+        Type of window function to return.
+
+    Returns
+    -------
+    w : np.ndarray[n]
+        Window function.
+    """
+
+    a_table = {
+        'nuttall': np.array([0.355768, -0.487396, 0.144232, -0.012604]),
+        'blackman_nuttall': np.array([0.3635819, -0.4891775, 0.1365995, -0.0106411]),
+        'blackman_harris': np.array([0.35875, -0.48829, 0.14128, -0.01168])
+    }
+
+    a = a_table[window]
+
+    t = 2 * np.pi * np.arange(4)[:, np.newaxis] * x[np.newaxis, :]
+
+    w = (a[:, np.newaxis] * np.cos(t)).sum(axis=0)
+
+    return w
+
+
+def fourier_matrix_r2c(N, fsel=None):
+    """Generate a Fourier matrix to represent a real to complex FFT.
+
+    Parameters
+    ----------
+    N : integer
+        Length of timestream that we are transforming to. Must be even.
+    fsel : array_like, optional
+        Indexes of the frequency channels to include in the transformation
+        matrix. By default, assume all channels.
+
+    Returns
+    -------
+    F : np.ndarray
+        An array performing the Fourier transform from a real time series to
+        frequencies packed as alternating real and imaginary elements,
+    """
+
+    if fsel is None:
+        fa = np.arange(N / 2 + 1)
+    else:
+        fa = np.array(fsel)
+
+    fa = fa[:, np.newaxis]
+    ta = np.arange(N)[np.newaxis, :]
+
+    Fr = np.zeros((2 * fa.shape[0], N), dtype=np.float64)
+
+    Fr[0::2] = np.cos(2 * np.pi * ta * fa / N)
+    Fr[1::2] = -np.sin(2 * np.pi * ta * fa / N)
+
+    return Fr
+
+
+def fourier_matrix_c2r(N, fsel=None):
+    """Generate a Fourier matrix to represent a complex to real FFT.
+
+    Parameters
+    ----------
+    N : integer
+        Length of timestream that we are transforming to. Must be even.
+    fsel : array_like, optional
+        Indexes of the frequency channels to include in the transformation
+        matrix. By default, assume all channels.
+
+    Returns
+    -------
+    F : np.ndarray
+        An array performing the Fourier transform from frequencies packed as
+        alternating real and imaginary elements, to the real time series.
+    """
+
+    if fsel is None:
+        fa = np.arange(N / 2 + 1)
+    else:
+        fa = np.array(fsel)
+
+    fa = fa[np.newaxis, :]
+
+    mul = np.where((fa == 0) | (fa == N / 2), 1.0, 2.0) / N
+
+    ta = np.arange(N)[:, np.newaxis]
+
+    Fr = np.zeros((N, 2 * fa.shape[1]), dtype=np.float64)
+
+    Fr[:, 0::2] = np.cos(2 * np.pi * ta * fa / N) * mul
+    Fr[:, 1::2] = -np.sin(2 * np.pi * ta * fa / N) * mul
+
+    return Fr
+
+
+def delay_spectrum_gibbs(data, N, Ni, initial_S, window=True, fsel=None, niter=20):
+    """Estimate the delay spectrum by Gibbs sampling.
+
+    This routine estimates the spectrum at the `N` delay samples conjugate to
+    the frequency spectrum of ``N/2 + 1`` channels. A subset of these channels
+    can be specified using the `fsel` argument.
+
+    Parameters
+    ----------
+    data : np.ndarray[:, freq]
+        Data to estimate the delay spectrum of.
+    N : int
+        The length of the output delay spectrum. There are assumed to `N/2 + 1`
+        total frequency channels.
+    Ni : np.ndarray[freq]
+        Inverse noise variance.
+    initial_S : np.ndarray[delay]
+        The initial delay spectrum guess.
+    window : bool, optional
+        Apply a Nuttall apodisation function. Default is True.
+    fsel : np.ndarray[freq], optional
+        Indices of channels that we have data at. By default assume all channels.
+    niter : int, optional
+        Number of Gibbs samples to generate.
+
+    Returns
+    -------
+    spec : list
+        List of spectrum samples.
+    """
+
+    spec = []
+
+    total_freq = N / 2 + 1
+
+    if fsel is None:
+        fsel = np.arange(total_freq)
+
+    # Construct the Fourier matrix
+    F = fourier_matrix_r2c(N, fsel)
+
+    # Construct a view of the data with alternating real and imaginary parts
+    data = data.astype(np.complex128, order='C').view(np.float64).T.copy()
+
+    # Window the frequency data
+    if window:
+
+        # Construct the window function
+        x = fsel * 1.0 / total_freq
+        w = window_generalised(x, window='nuttall')
+        w = np.repeat(w, 2)
+
+        # Apply to the projection matrix and the data
+        F *= w[:, np.newaxis]
+        data *= w[:, np.newaxis]
+
+    is_real_freq = (fsel == 0) | (fsel == N / 2)
+
+    # Construct the Noise inverse array for the real and imaginary parts (taking
+    # into account that the zero and Nyquist frequencies are strictly real)
+    Ni_r = np.zeros(2 * Ni.shape[0])
+    Ni_r[0::2] = np.where(is_real_freq, Ni, Ni / 2**0.5)
+    Ni_r[1::2] = np.where(is_real_freq, 0.0, Ni / 2**0.5)
+
+    # Create the Hermitian conjugate weighted by the noise (this is used multiple times)
+    FTNi = F.T * Ni_r[np.newaxis, :]
+    FTNiF = np.dot(FTNi, F)
+
+    # Set the initial starting points
+    S_samp = initial_S
+
+    def _draw_signal_sample(S):
+        # Draw a random sample of the signal assuming a Gaussian model with a
+        # given delay spectrum shape. Do this using the perturbed Wiener filter
+        # approach
+
+        # TODO: we can probably change the order that the Wiener filter is
+        # evaluated for some computational saving as nfreq < ndelay
+
+        # Construct the Wiener covariance
+        Si = 1.0 / S
+        Ci = np.diag(Si) + FTNiF
+
+        # Draw random vectors that form the perturbations
+        w1 = np.random.standard_normal((N, data.shape[1]))
+        w2 = np.random.standard_normal(data.shape)
+
+        # Construct the random signal sample by forming a perturbed vector and
+        # then doing a matrix solve
+        y = (np.dot(FTNi, data) + Si[:, np.newaxis]**0.5 * w1 +
+             np.dot(F.T, Ni_r[:, np.newaxis]**0.5 * w2))
+
+        return la.solve(Ci, y, sym_pos=True)
+
+    def _draw_ps_sample(d):
+        # Draw a random power spectrum sample assuming from the signal assuming
+        # the signal is Gaussian and we have a flat prior on the power spectrum.
+        # This means drawing from a inverse chi^2.
+
+        S_hat = d.var(axis=1)
+
+        df = d.shape[1]
+        chi2 = st.chi2.rvs(df, size=d.shape[0])
+
+        S_samp = S_hat * df / chi2
+
+        return S_samp
+
+    # Perform the Gibbs sampling iteration for a given number of loops and
+    # return the power spectrum output of them.
+    for ii in range(niter):
+
+        d_samp = _draw_signal_sample(S_samp)
+        S_samp = _draw_ps_sample(d_samp)
+
+        spec.append(S_samp)
+
+    return spec
+
+
+def null_delay_filter(freq, max_delay, mask, num_delay=200, tol=1e-8, window=True):
+    """Take frequency data and null out any delays below some value.
+
+    Parameters
+    ----------
+    freq : np.ndarray[freq]
+        Frequencies we have data at.
+    max_delay : float
+        Maximum delay to keep.
+    mask : np.ndarray[freq]
+        Frequencies to mask out.
+    num_delay : int, optional
+        Number of delay values to use.
+    tol : float, optional
+        Cut off value for singular values.
+    window : bool, optional
+        Apply a window function to the data while filtering.
+
+    Returns
+    -------
+    filter : np.ndarray[freq, freq]
+        The filter as a 2D matrix.
+    """
+
+    # Construct the window function
+    x = (freq - freq.min()) / freq.ptp()
+    w = window_generalised(x, window='nuttall')
+
+    delay = np.linspace(-max_delay, max_delay, num_delay)
+
+    # Construct the Fourier matrix
+    F = (mask * w)[:, np.newaxis] * np.exp(2.0J * np.pi * delay[np.newaxis, :] * freq[:, np.newaxis])
+
+    # Use an SVD to figure out the set of significant modes spanning the delays
+    # we are wanting to get rid of.
+    u, sig, vh = la.svd(F)
+    nmodes = np.sum(sig > tol * sig.max())
+    p = u[:, :nmodes]
+
+    # Construct a projection matrix for the filter
+    proj = np.identity(len(freq)) - np.dot(p, p.T.conj())
+
+    if window:
+        proj = (mask * w)[np.newaxis, :] * proj
+
+    return proj

--- a/draco/analysis/fgfilter.py
+++ b/draco/analysis/fgfilter.py
@@ -1,0 +1,272 @@
+"""Tasks for foreground filtering data.
+"""
+
+import numpy as np
+
+from caput import config
+from ..core import task, containers, io
+
+
+def enum(options, default=None):
+    """A property type that accepts only a set of possible values.
+
+    Parameters
+    ----------
+    options : list
+        List of allowed options.
+    default : optional
+        The optional default value.
+
+    Returns
+    -------
+    prop : Property
+        A property instance setup to validate an enum type.
+
+    Examples
+    --------
+    Should be used like::
+
+        class Project(object):
+
+            mode = enum(['forward', 'backward'], default='forward')
+    """
+
+    def _prop(val):
+
+        if val not in options:
+            raise ValueError('Input %f not in %s' % (repr(val), repr(options)))
+
+        return val
+
+    if default is not None and default not in options:
+        raise ValueError('Default value %s must be in %s (or None)' %
+                         (repr(default), repr(options)))
+
+    prop = config.Property(proptype=_prop, default=default)
+
+    return prop
+
+
+class _ProjectFilterBase(task.SingleTask):
+    """A base class for projecting data to/from a different basis.
+
+    Attributes
+    ----------
+    mode : string
+        Which projection to perform. Into the new basis (forward), out of the
+        new basis (backward), and forward then backward in order to filter the
+        data through the basis (filter).
+    """
+
+    mode = enum(['forward', 'backward', 'filter'], default='forward')
+
+    def process(self, inp):
+        """Project or filter the input data.
+
+        Parameters
+        ----------
+        inp : memh5.BasicCont
+            Data to process.
+
+        Returns
+        -------
+        output : memh5.BasicCont
+        """
+
+        if self.mode == 'forward':
+            return self._forward(inp)
+
+        if self.mode == 'backward':
+            return self._backward(inp)
+
+        if self.mode == 'filter':
+            return self._backward(self._forward(inp))
+
+    def _forward(self, inp):
+        pass
+
+    def _backward(self, inp):
+        pass
+
+
+class SVDModeProject(_ProjectFilterBase):
+    """SVD projection between the raw m-modes and the reduced degrees of freedom.
+
+    Note that this produces the packed SVD modes, with the modes from each
+    frequency concatenated.
+    """
+
+    def setup(self, bt):
+        """Set the beamtransfer instance.
+
+        Parameters
+        ----------
+        bt : BeamTransfer
+            This can also take a ProductManager instance.
+        """
+        self.beamtransfer = io.get_beamtransfer(bt)
+
+    def _forward(self, mmodes):
+        # Forward transform into SVD basis
+
+        bt = self.beamtransfer
+        tel = bt.telescope
+
+        svdmodes = containers.SVDModes(mode=bt.ndofmax, axes_from=mmodes,
+                                       attrs_from=mmodes)
+        mmodes.redistribute('m')
+        svdmodes.redistribute('m')
+
+        # Iterate over local m's, project mode and save to disk.
+        for lm, mi in mmodes.vis[:].enumerate(axis=0):
+
+            tm = mmodes.vis[mi].reshape(tel.nfreq, 2 * tel.npairs)
+            svdm = bt.project_vector_telescope_to_svd(mi, tm)
+
+            svdmodes.nmode[mi] = len(svdm)
+            svdmodes.vis[mi, :svdmodes.nmode[mi]] = svdm
+
+            # TODO: apply transform correctly to weights. For now just crudely
+            # transfer over the weights, only really good for determining
+            # whether an m-mode should be masked comoletely
+            svdmodes.weight[mi] = np.median(mmodes.weight[mi])
+
+        return svdmodes
+
+    def _backward(self, svdmodes):
+        # Backward transform from SVD basis into the m-modes
+
+        bt = self.beamtransfer
+        tel = bt.telescope
+
+        # Try and fetch out the feed index and info from the telescope object.
+        try:
+            feed_index = tel.input_index
+        except AttributeError:
+            feed_index = tel.nfeed
+
+        # Construct frequency index map
+        freqmap = np.zeros(
+            len(tel.frequencies),
+            dtype=[('centre', np.float64), ('width', np.float64)]
+        )
+        freqmap['centre'][:] = tel.frequencies
+        freqmap['width'][:] = np.abs(np.diff(tel.frequencies)[0])
+
+        # Construct the new m-mode container
+        mmodes = containers.MModes(freq=freqmap, prod=tel.uniquepairs,
+                                   input=feed_index, attrs_from=svdmodes,
+                                   axes_from=svdmodes)
+        mmodes.redistribute('m')
+        svdmodes.redistribute('m')
+
+        # Iterate over local m's, project mode and save to disk.
+        for lm, mi in mmodes.vis[:].enumerate(axis=0):
+
+            svdm = svdmodes.vis[mi]
+            tm = bt.project_vector_svd_to_telescope(mi, svdm)
+
+            svdmodes.nmode[mi] = len(svdm)
+            mmodes.vis[mi] = tm.transpose((1, 0, 2))
+
+            # TODO: apply transform correctly to weights. For now just crudely
+            # transfer over the weights, only really good for determining
+            # whether an m-mode should be masked comoletely
+            mmodes.weight[mi] = np.median(svdmodes.weight[mi])
+
+        return mmodes
+
+
+class KLModeProject(_ProjectFilterBase):
+    """Project between the SVD and KL basis.
+
+    Attributes
+    ----------
+    threshold : float, optional
+        KL mode threshold.
+    klname : str
+        Name of filter to use.
+    mode : string
+        Which projection to perform. Into the KL basis (forward), out of the
+        KL basis (backward), and forward then backward in order to KL filter the
+        data through the basis (filter).
+    """
+
+    threshold = config.Property(proptype=float, default=None)
+    klname = config.Property(proptype=str)
+
+    def setup(self, manager):
+        """Set the product manager that holds the saved KL modes.
+        """
+        self.product_manager = manager
+
+    def _forward(self, svdmodes):
+        # Forward transform into the KL modes
+
+        bt = self.product_manager.beamtransfer
+
+        # Check and set the KL basis we are using
+        if self.klname not in self.product_manager.kltransforms:
+            raise RuntimeError(
+                'Requested KL basis %s not available (options are %s)' %
+                (self.klname, repr(self.product_manager.kltransforms.items()))
+            )
+        kl = self.product_manager.kltransforms[self.klname]
+
+        # Construct the container and redistribute
+        klmodes = containers.KLModes(mode=bt.ndofmax, axes_from=svdmodes,
+                                     attrs_from=svdmodes)
+        klmodes.redistribute('m')
+        svdmodes.redistribute('m')
+
+        # Iterate over local m's and project mode into KL basis
+        for lm, mi in svdmodes.vis[:].enumerate(axis=0):
+
+            sm = svdmodes.vis[mi][:svdmodes.nmode[mi]]
+            klm = kl.project_vector_svd_to_kl(mi, sm, threshold=self.threshold)
+
+            klmodes.nmode[mi] = len(klm)
+            klmodes.vis[mi, :klmodes.nmode[mi]] = klm
+
+            # TODO: apply transform correctly to weights. For now just crudely
+            # transfer over the weights, only really good for determining
+            # whether an m-mode should be masked comoletely
+            klmodes.weight[mi] = np.median(svdmodes.weight[mi])
+
+        return klmodes
+
+    def _backward(self, klmodes):
+        # Backward transform from the KL modes into the SVD modes
+
+        bt = self.product_manager.beamtransfer
+
+        # Check and set the KL basis we are using
+        if self.klname not in self.product_manager.kltransforms:
+            raise RuntimeError(
+                'Requested KL basis %s not available (options are %s)' %
+                (self.klname, repr(self.product_manager.kltransforms.items()))
+            )
+        kl = self.product_manager.kltransforms[self.klname]
+
+        # Construct the container and redistribute
+
+        svdmodes = containers.SVDModes(mode=bt.ndofmax, axes_from=klmodes,
+                                       attrs_from=klmodes)
+        klmodes.redistribute('m')
+        svdmodes.redistribute('m')
+
+        # Iterate over local m's and project mode into KL basis
+        for lm, mi in klmodes.vis[:].enumerate(axis=0):
+
+            klm = klmodes.vis[mi][:klmodes.nmode[mi]]
+            sm = kl.project_vector_kl_to_svd(mi, klm, threshold=self.threshold)
+
+            svdmodes.nmode[mi] = len(sm)
+            svdmodes.vis[mi, :svdmodes.nmode[mi]] = sm
+
+            # TODO: apply transform correctly to weights. For now just crudely
+            # transfer over the weights, only really good for determining
+            # whether an m-mode should be masked comoletely
+            svdmodes.weight[mi] = np.median(klmodes.weight[mi])
+
+        return svdmodes

--- a/draco/analysis/fgfilter.py
+++ b/draco/analysis/fgfilter.py
@@ -7,46 +7,6 @@ from caput import config
 from ..core import task, containers, io
 
 
-def enum(options, default=None):
-    """A property type that accepts only a set of possible values.
-
-    Parameters
-    ----------
-    options : list
-        List of allowed options.
-    default : optional
-        The optional default value.
-
-    Returns
-    -------
-    prop : Property
-        A property instance setup to validate an enum type.
-
-    Examples
-    --------
-    Should be used like::
-
-        class Project(object):
-
-            mode = enum(['forward', 'backward'], default='forward')
-    """
-
-    def _prop(val):
-
-        if val not in options:
-            raise ValueError('Input %f not in %s' % (repr(val), repr(options)))
-
-        return val
-
-    if default is not None and default not in options:
-        raise ValueError('Default value %s must be in %s (or None)' %
-                         (repr(default), repr(options)))
-
-    prop = config.Property(proptype=_prop, default=default)
-
-    return prop
-
-
 class _ProjectFilterBase(task.SingleTask):
     """A base class for projecting data to/from a different basis.
 
@@ -58,7 +18,7 @@ class _ProjectFilterBase(task.SingleTask):
         data through the basis (filter).
     """
 
-    mode = enum(['forward', 'backward', 'filter'], default='forward')
+    mode = config.enum(['forward', 'backward', 'filter'], default='forward')
 
     def process(self, inp):
         """Project or filter the input data.

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from caput import config
 
-from ..core import task, containers
+from ..core import task, containers, io
 from ..util import tools
 
 
@@ -171,7 +171,7 @@ class MaskBaselines(task.SingleTask):
         telescope : TransitTelescope
         """
 
-        self.telescope = telescope
+        self.telescope = io.get_telescope(telescope)
 
     def process(self, ss):
         """Apply the mask to data.

--- a/draco/analysis/mapmaker.py
+++ b/draco/analysis/mapmaker.py
@@ -14,7 +14,7 @@ Tasks
 import numpy as np
 from caput import mpiarray, config
 
-from ..core import containers, task
+from ..core import containers, task, io
 
 
 class BaseMapMaker(task.SingleTask):
@@ -33,12 +33,12 @@ class BaseMapMaker(task.SingleTask):
 
         Parameters
         ----------
-        bt : beamtransfer.BeamTransfer
-            Beam transfer manager object containing all the pre-generated beam
-            transfer matrices.
+        bt : beamtransfer.BeamTransfer or manager.ProductManager
+            Beam transfer manager object (or ProductManager) containing all the
+            pre-generated beam transfer matrices.
         """
 
-        self.beamtransfer = bt
+        self.beamtransfer = io.get_beamtransfer(bt)
 
     def process(self, mmodes):
         """Make a map from the given m-modes.

--- a/draco/analysis/powerspectrum.py
+++ b/draco/analysis/powerspectrum.py
@@ -1,0 +1,90 @@
+"""Power spectrum estimation code.
+"""
+
+import numpy as np
+
+from caput import config
+from ..core import task, containers
+
+
+class QuadraticPSEstimation(task.SingleTask):
+    """Estimate a power spectrum from a set of KLModes.
+
+    Attributes
+    ----------
+    psname : str
+        Name of power spectrum to use. Must be precalculated in the driftscan
+        products.
+    pstype : str
+        Type of power spectrum estimate to calculate. One of 'unwindowed',
+        'minimum_variance' or 'uncorrelated'.
+    """
+
+    psname = config.Property(proptype=str)
+
+    pstype = config.enum(['unwindowed', 'minimum_variance', 'uncorrelated'],
+                         default='unwindowed')
+
+    def setup(self, manager):
+        """Set the ProductManager instance to use.
+
+        Parameters
+        ----------
+        manager : ProductManager
+        """
+        self.manager = manager
+
+    def process(self, klmodes):
+        """Estimate the power spectrum from the given data.
+
+        Parameters
+        ----------
+        klmodes : containers.KLModes
+
+        Returns
+        -------
+        ps : containers.PowerSpectrum
+        """
+
+        import scipy.linalg as la
+
+        if not isinstance(klmodes, containers.KLModes):
+            raise ValueError('Input container must be instance of '
+                             'KLModes (received %s)' % klmodes.__class__)
+
+        klmodes.redistribute('m')
+
+        pse = self.manager.psestimators[self.psname]
+        pse.genbands()
+
+        q_list = []
+
+        for mi, m in klmodes.vis[:].enumerate(axis=0):
+
+            ps_single = pse.q_estimator(m, klmodes.vis[m, :klmodes.nmode[m]])
+            q_list.append(ps_single)
+
+        q = klmodes.comm.allgather(np.array(q_list).sum(axis=0))
+        q = np.array(q).sum(axis=0)
+
+        fisher, bias = pse.fisher_bias()
+
+        ps = containers.Powerspectrum2D(kpar_edges=pse.kpar_bands,
+                                        kperp_edges=pse.kperp_bands)
+
+        npar = len(ps.index_map['kpar'])
+        nperp = len(ps.index_map['kperp'])
+
+        # Calculate the right unmixing matrix for each ps type
+        if self.pstype == 'unwindowed':
+            M = la.inv(fisher)
+        elif self.pstype == 'uncorrelated':
+            Fh = la.cholesky(fisher)
+            M = la.inv(Fh) / Fh.sum(axis=1)[:, np.newaxis]
+        elif self.pstype == 'minimum_variance':
+            M = np.diag(fisher.sum(axis=1)**-1)
+
+        ps.powerspectrum[:] = np.dot(M, q - bias).reshape(npar, nperp)
+        ps.C_inv[:] = fisher.reshape(npar, nperp, npar, nperp)
+
+        return ps

--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -1,0 +1,189 @@
+"""A set of tasks for SVD filtering the m-modes.
+"""
+
+import numpy as np
+import scipy.linalg as la
+
+from caput import config
+
+from draco.core import task, containers
+
+
+class SVDSpectrumEstimator(task.SingleTask):
+    """Calculate the SVD spectrum of a set of m-modes.
+
+    Attributes
+    ----------
+    niter : int
+        Number of iterations of EM to perform.
+    """
+
+    niter = config.Property(proptype=int, default=5)
+
+    def process(self, mmodes):
+        """Calculate the spectrum.
+
+        Parameters
+        ----------
+        mmodes : containers.MModes
+            MModes to find the spectrum of.
+
+        Returns
+        -------
+        spectrum : containers.SVDSpectrum
+        """
+
+        mmodes.redistribute('m')
+
+        vis = mmodes.vis[:]
+        weight = mmodes.weight[:]
+
+        nmode = min(vis.shape[1] * vis.shape[3], vis.shape[2])
+
+        spec = containers.SVDSpectrum(singularvalue=nmode, axes_from=mmodes)
+        spec.spectrum[:] = 0.0
+
+        for mi, m in vis.enumerate(axis=0):
+            self.log.debug("Calculating SVD spectrum of m=%i", m)
+
+            vis_m = (vis[mi].view(np.ndarray)
+                     .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            weight_m = (weight[mi].view(np.ndarray)
+                        .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            mask_m = (weight_m == 0.0)
+
+            u, sig, vh = svd_em(vis_m, mask_m, niter=self.niter)
+
+            spec.spectrum[m] = sig
+
+        return spec
+
+
+class SVDFilter(task.SingleTask):
+    """SVD filter the m-modes to remove the most correlated components.
+
+    Attributes
+    ----------
+    niter : int
+        Number of iterations of EM to perform.
+    local_threshold : float
+        Cut out modes with singular value higher than `local_threshold` times the
+        largest mode on each m.
+    global_threshold : float
+        Remove modes with singular value higher than `global_threshold` times the
+        largest mode on any m
+    """
+
+    niter = config.Property(proptype=int, default=5)
+    global_threshold = config.Property(proptype=float, default=1e-3)
+    local_threshold = config.Property(proptype=float, default=1e-2)
+
+    def process(self, mmodes):
+        """Filter MModes using an SVD.
+
+        Parameters
+        ----------
+        mmodes : container.MModes
+
+        Returns
+        -------
+        mmodes : container.MModes
+        """
+
+        from mpi4py import MPI
+
+        mmodes.redistribute('m')
+
+        vis = mmodes.vis[:]
+        weight = mmodes.weight[:]
+
+        sv_max = 0.0
+
+        # Do a quick first pass calculation of all the singular values to get the max on this rank.
+        for mi, m in vis.enumerate(axis=0):
+
+            vis_m = (vis[mi].view(np.ndarray)
+                     .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            weight_m = (weight[mi].view(np.ndarray)
+                        .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            mask_m = (weight_m == 0.0)
+
+            u, sig, vh = svd_em(vis_m, mask_m, niter=self.niter)
+
+            sv_max = max(sig[0], sv_max)
+
+        # Reduce to get the global max.
+        global_max = mmodes.comm.allreduce(sv_max, op=MPI.MAX)
+
+        self.log.debug("Global maximum singular value=%.2g", global_max)
+        import sys
+        sys.stdout.flush()
+
+        # Loop over all m's and remove modes below the combined cut
+        for mi, m in vis.enumerate(axis=0):
+
+            vis_m = (vis[mi].view(np.ndarray)
+                     .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            weight_m = (weight[mi].view(np.ndarray)
+                        .transpose((1, 0, 2)).reshape(vis.shape[2], -1))
+            mask_m = (weight_m == 0.0)
+
+            u, sig, vh = svd_em(vis_m, mask_m, niter=self.niter)
+
+            # Zero out singular values below the combined mode cut
+            global_cut = (sig > self.global_threshold * global_max).sum()
+            local_cut = (sig > self.local_threshold * sig[0]).sum()
+            cut = max(global_cut, local_cut)
+            sig[:cut] = 0.0
+
+            # Recombine the matrix
+            vis_m = np.dot(u, sig[:, np.newaxis] * vh)
+
+            # Reshape and write back into the mmodes container
+            vis[mi] = vis_m.reshape(vis.shape[2], 2, -1).transpose((1, 0, 2))
+
+        return mmodes
+
+
+def svd_em(A, mask, niter=5, rank=5, full_matrices=False):
+    """Perform an SVD with missing entries using Expectation-Maximisation.
+
+    This assumes that the matrix is well approximated by only a few modes in
+    order fill the missing entries. This is probably not a proper EM scheme, but
+    is not far off.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Matrix to SVD.
+    mask : np.ndarray
+        Boolean array of masked values. Missing values are `True`.
+    niter : int, optional
+        Number of iterations to perform.
+    rank : int, optional
+        Set the rank of the approximation used to fill the missing values.
+    full_matrices : bool, optional
+        Return the full span of eigenvectors and values (see `scipy.linalg.svd`
+        for a fuller description).
+
+    Returns
+    -------
+    u, sig, vh : np.ndarray
+        The singular values and vectors.
+    """
+
+    # Do an initial fill of the missing entries
+    A = A.copy()
+    A[mask] = np.median(A)
+
+    # Perform cycles of calculating the SVD with the current guess for the
+    # missing values, then forming a new estimate of the missing values using a
+    # low rank approximation.
+    for i in range(niter):
+
+        u, sig, vh = la.svd(A, full_matrices=full_matrices, overwrite_a=False)
+
+        low_rank_A = np.dot(u[:, :rank] * sig[:rank], vh[:rank])
+        A[mask] = low_rank_A[mask]
+
+    return u, sig, vh

--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -99,6 +99,9 @@ class SVDFilter(task.SingleTask):
 
         sv_max = 0.0
 
+        # TODO: this should be changed such that it does all the computation in
+        # a single SVD pass.
+
         # Do a quick first pass calculation of all the singular values to get the max on this rank.
         for mi, m in vis.enumerate(axis=0):
 

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -15,7 +15,7 @@ Tasks
 import numpy as np
 from caput import mpiarray, config
 
-from ..core import containers, task
+from ..core import containers, task, io
 from ..util import tools
 
 
@@ -111,7 +111,7 @@ class CollateProducts(task.SingleTask):
         tel : TransitTelescope
         """
 
-        self.telescope = tel
+        self.telescope = io.get_telescope(tel)
 
     def process(self, ss):
         """Select and reorder the products.

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -103,16 +103,15 @@ class CollateProducts(task.SingleTask):
     the timestream object.
     """
 
-    def setup(self, bt):
+    def setup(self, tel):
         """Set the BeamTransfer instance to use.
 
         Parameters
         ----------
-        bt : BeamTransfer
+        tel : TransitTelescope
         """
 
-        self.beamtransfer = bt
-        self.telescope = bt.telescope
+        self.telescope = tel
 
     def process(self, ss):
         """Select and reorder the products.

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -621,14 +621,8 @@ class MModes(ContainerBase):
 
     Parameters
     ----------
-    mmax : integer
-        Number of samples in RA.
-    nfreq : integer
-        Number of frequencies.
-    ncorr : integer
-        Number of correlation products.
-    comm : MPI.Comm
-        MPI communicator to distribute over.
+    mmax : integer, optional
+        Largest m to be held.
 
     Attributes
     ----------
@@ -667,10 +661,6 @@ class MModes(ContainerBase):
         return self.datasets['vis_weight']
 
     @property
-    def ra(self):
-        return self.index_map['ra']
-
-    @property
     def freq(self):
         return self.index_map['freq']
 
@@ -688,6 +678,89 @@ class MModes(ContainerBase):
         kwargs['msign'] = np.array(['+', '-'])
 
         super(MModes, self).__init__(*args, **kwargs)
+
+
+class SVDModes(ContainerBase):
+    """Parallel container for holding SVD m-mode data.
+
+    Parameters
+    ----------
+    mmax : integer, optional
+        Largest m to be held.
+
+    Attributes
+    ----------
+    vis : mpidataset.MPIArray
+        Visibility array.
+    weight : mpidataset.MPIArray
+        Array of weights for each point.
+    """
+
+    _axes = ('m', 'mode')
+
+    _dataset_spec = {
+        'vis': {
+            'axes': ['m', 'mode'],
+            'dtype': np.complex128,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'm'
+        },
+
+        'vis_weight': {
+            'axes': ['m', 'mode'],
+            'dtype': np.float64,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'm'
+        },
+
+        'nmode': {
+            'axes': ['m'],
+            'dtype': np.int32,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'm'
+        }
+    }
+
+    @property
+    def vis(self):
+        return self.datasets['vis']
+
+    @property
+    def nmode(self):
+        return self.datasets['nmode']
+
+    @property
+    def weight(self):
+        return self.datasets['vis_weight']
+
+    def __init__(self, mmax=None, *args, **kwargs):
+
+        # Set up axes from passed arguments
+        if mmax is not None:
+            kwargs['m'] = mmax + 1
+
+        super(SVDModes, self).__init__(*args, **kwargs)
+
+
+class KLModes(SVDModes):
+    """Parallel container for holding KL filtered m-mode data.
+
+    Parameters
+    ----------
+    mmax : integer, optional
+        Largest m to be held.
+
+    Attributes
+    ----------
+    vis : mpidataset.MPIArray
+        Visibility array.
+    weight : mpidataset.MPIArray
+        Array of weights for each point.
+    """
+    pass
 
 
 class GainData(TODContainer):
@@ -786,6 +859,27 @@ class DelaySpectrum(ContainerBase):
             'initialise': True,
             'distributed': True,
             'distributed_axis': 'baseline'
+        }
+    }
+
+    @property
+    def spectrum(self):
+        return self.datasets['spectrum']
+
+
+class SVDSpectrum(ContainerBase):
+    """Container for an m-mode SVD spectrum.
+    """
+
+    _axes = ('m', 'singularvalue')
+
+    _dataset_spec = {
+        'spectrum': {
+            'axes': ['m', 'singularvalue'],
+            'dtype': np.float64,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'm'
         }
     }
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -867,6 +867,79 @@ class DelaySpectrum(ContainerBase):
         return self.datasets['spectrum']
 
 
+class Powerspectrum2D(ContainerBase):
+    """Container for a 2D cartesian power spectrum.
+
+    Generally you should set the standard attributes `z_start` and `z_end` with
+    the redshift range included in the power spectrum estimate, and the `type`
+    attribute with a description of the estimator type. Suggested valued for
+    `type` are:
+
+    `unwindowed`
+        The standard unbiased quadratic estimator.
+
+    `minimum_variance`
+        The minimum variance, but highly correlated, estimator. Just a rescaled
+        version of the q-estimator.
+
+    `uncorrelated`
+        The uncorrelated estimator using the root of the Fisher matrix.
+
+    Parameters
+    ----------
+    kpar_edges, kperp_edges : np.ndarray
+        Array of the power spectrum bin boundaries.
+    """
+
+    _axes = ('kpar', 'kperp')
+
+    _dataset_spec = {
+        'powerspectrum': {
+            'axes': ['kpar', 'kperp'],
+            'dtype': np.float64,
+            'initialise': True,
+            'distributed': False
+        },
+
+        'C_inv': {
+            'axes': ['kpar', 'kperp', 'kpar', 'kperp'],
+            'dtype': np.float64,
+            'initialise': True,
+            'distributed': False
+        }
+    }
+
+    def __init__(self, kpar_edges=None, kperp_edges=None, *args, **kwargs):
+
+        # Construct the kpar axis from the bin edges
+        if kpar_edges is not None:
+            centre = 0.5 * (kpar_edges[1:] + kpar_edges[:-1])
+            width = kpar_edges[1:] - kpar_edges[:-1]
+
+            kwargs['kpar'] = np.rec.fromarrays(
+                [centre, width], names=['centre', 'width']
+            ).view(np.ndarray)
+
+        # Construct the kperp axis from the bin edges
+        if kperp_edges is not None:
+            centre = 0.5 * (kperp_edges[1:] + kperp_edges[:-1])
+            width = kperp_edges[1:] - kperp_edges[:-1]
+
+            kwargs['kperp'] = np.rec.fromarrays(
+                [centre, width], names=['centre', 'width']
+            ).view(np.ndarray)
+
+        super(Powerspectrum2D, self).__init__(*args, **kwargs)
+
+    @property
+    def powerspectrum(self):
+        return self.datasets['powerspectrum']
+
+    @property
+    def C_inv(self):
+        return self.datasets['C_inv']
+
+
 class SVDSpectrum(ContainerBase):
     """Container for an m-mode SVD spectrum.
     """

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -773,6 +773,27 @@ class StaticGainData(ContainerBase):
         return self.index_map['input']
 
 
+class DelaySpectrum(ContainerBase):
+    """Container for a delay spectrum.
+    """
+
+    _axes = ('baseline', 'delay')
+
+    _dataset_spec = {
+        'spectrum': {
+            'axes': ['baseline', 'delay'],
+            'dtype': np.float64,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'baseline'
+        }
+    }
+
+    @property
+    def spectrum(self):
+        return self.datasets['spectrum']
+
+
 class SourceCatalog(TableBase):
     """A basic container for holding astronomical source catalogs.
 

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -115,13 +115,13 @@ class SetMPILogging(pipeline.TaskBase):
         rank_length = int(math.log10(MPI.COMM_WORLD.size)) + 1
 
         mpi_fmt = "[MPI %%(mpi_rank)%id/%%(mpi_size)%id]" % (rank_length, rank_length)
+        filt = MPILogFilter(level_all=self.level_all, level_rank0=self.level_rank0)
 
+        # This uses the fact that caput.pipeline.Manager has already
+        # attempted to set up the logging. We just override the level, and
+        # insert our custom filter
         root_logger = logging.getLogger()
         root_logger.setLevel(logging.DEBUG)
-
-        filt = MPILogFilter()
-
-        # create console handler and set level to debug
         ch = root_logger.handlers[0]
         ch.setLevel(logging.DEBUG)
         ch.addFilter(filt)

--- a/draco/synthesis/stream.py
+++ b/draco/synthesis/stream.py
@@ -160,7 +160,7 @@ class ExpandProducts(task.SingleTask):
         tel : :class:`drift.core.TransitTelescope`
             Telescope object.
         """
-        self.telescope = telescope
+        self.telescope = io.get_telescope(telescope)
 
     def process(self, sstream):
         """Transform a sidereal stream to having a full product matrix.

--- a/draco/synthesis/stream.py
+++ b/draco/synthesis/stream.py
@@ -21,7 +21,7 @@ import numpy as np
 from cora.util import hputil
 from caput import mpiutil, pipeline, config, mpiarray
 
-from ..core import containers, task
+from ..core import containers, task, io
 
 
 class SimulateSidereal(task.SingleTask):
@@ -30,16 +30,16 @@ class SimulateSidereal(task.SingleTask):
 
     done = False
 
-    def setup(self, beamtransfer):
+    def setup(self, bt):
         """Setup the simulation.
 
         Parameters
         ----------
-        bt : BeamTransfer
+        bt : ProductManager or BeamTransfer
             Beam Transfer maanger.
         """
-        self.beamtransfer = beamtransfer
-        self.telescope = beamtransfer.telescope
+        self.beamtransfer = io.get_beamtransfer(bt)
+        self.telescope = io.get_telescope(bt)
 
     def process(self, map_):
         """Simulate a SiderealStream

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ext_modules=cythonize([fast_ext]),
 
     install_requires=['Cython>0.18', 'numpy>=1.7', 'scipy>=0.10',
-                      'caput>=0.3', 'cora', 'driftscan>=0.2'],
+                      'caput>=0.4', 'cora', 'driftscan>=1.2'],
 
     author="Richard Shaw",
     author_email="richard@phas.ubc.ca",


### PR DESCRIPTION
This pull request introduces a major set of new functionality to draco:

 - Adds in delay spectrum estimation and filtering.
 - SVD based foreground filtering on the m-modes
 - KL/SVD foreground filtering
 - Quadratic power spectrum estimation

There's also a few minor changes:

 - Added a new `LoadProductManager` task which loads the full interface to the driftscan generated analysis products. In many places this can be used instead of BeamTransfer or Telescope objects and so `LoadProductManager` should replace `LoadBeamTransfers` in most circumstances.
 - Fixes to the logging support,