### PR TITLE
noise fix

### DIFF
--- a/draco/synthesis/noise.py
+++ b/draco/synthesis/noise.py
@@ -130,7 +130,7 @@ class GaussianNoise(task.SingleTask):
         # Construct and set the correct weights in place
         if self.set_weights:
             for lfi, fi in visdata.enumerate(0):
-                data.weight[lfi] = 2.0 / std**2
+                data.weight[lfi] = 0.5 / std**2
 
         return data
 


### PR DESCRIPTION
if we want the weight to be 1/var and var = 50**/nsamp then we have to multiple the 1/std^2 by 0.5.
I think with 2 / std^2 we are off by a factor of 4