### PR TITLE
stack can only be created when prod is not None

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -682,7 +682,7 @@ class TimeStream(TODContainer):
             nfeed = inputs if isinstance(inputs, int) else len(inputs)
             kwargs['prod'] = np.array([[fi, fj] for fi in range(nfeed) for fj in range(fi, nfeed)])
 
-        if stack is None:
+        if stack is None and prod is not None:
             stack = np.empty_like(prod, dtype=[('prod', '<u4'), ('conjugate', 'u1')])
             stack['prod'][:] = np.arange(len(prod))
             stack['conjugate'] = 0


### PR DESCRIPTION
For simulating timestream data, stack can only be created when prod is not None otherwise it crashes on line 687
`TypeError: object of type 'NoneType' has no len()`