### PR TITLE
Fast collate products

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -135,6 +135,12 @@ class CollateProducts(task.SingleTask):
                                   for upp in self.telescope.uniquepairs],
                                   dtype=[('prod', '<u4'), ('conjugate', 'u1')])
 
+        # Construct the equivalent prod and stack index_map for the telescope instance
+        dt_prod = np.dtype([('input_a', '<u2'), ('input_b', '<u2')])
+        self.bt_prod = (np.array(np.triu_indices(self.telescope.nfeed))
+                        .astype('<u2').T.copy().view(dt_prod).reshape(-1))
+
+
 
     def process(self, ss):
         """Select and reorder the products.
@@ -208,10 +214,6 @@ class CollateProducts(task.SingleTask):
 
         bt_freq = ss.index_map['freq'][freq_ind]
 
-        # Construct the equivalent prod and stack index_map for the telescope instance
-        dt_prod = np.dtype([('input_a', '<u2'), ('input_b', '<u2')])
-        bt_prod = np.array(np.triu_indices(self.telescope.nfeed)).astype('<u2').T.copy().view(dt_prod).reshape(-1)
-
         # Construct the equivalent stack reverse_map for the telescope instance.  Note
         # that we identify invalid products here using an index that is the size of the stack axis.
         feedmask = pack_product_array(self.telescope.feedmask)
@@ -226,7 +228,7 @@ class CollateProducts(task.SingleTask):
         else:
             OutputContainer = containers.TimeStream
 
-        sp = OutputContainer(freq=bt_freq, input=bt_keys, prod=bt_prod,
+        sp = OutputContainer(freq=bt_freq, input=bt_keys, prod=self.bt_prod,
                              stack=self.bt_stack, reverse_map_stack=bt_rev,
                              axes_from=ss, attrs_from=ss, distributed=True, comm=ss.comm)
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -148,13 +148,13 @@ class ContainerBase(memh5.BasicCont):
         elif axes_from is not None and 'stack' in axes_from.reverse_map:
             reverse_map_stack = axes_from.reverse_map['stack']
 
-        # Set the reverse_map['stack'] if we have a definition, 
-        # otherwise do NOT throw an error, errors are thrown in 
+        # Set the reverse_map['stack'] if we have a definition,
+        # otherwise do NOT throw an error, errors are thrown in
         # classes that actually need a reverse stack
         if reverse_map_stack is not None:
             self.create_reverse_map('stack', reverse_map_stack)
 
-        
+
         # Iterate over datasets and initialise any that specify it
         for name, spec in self.dataset_spec.items():
             if 'initialise' in spec and spec['initialise']:
@@ -682,7 +682,7 @@ class TimeStream(TODContainer):
             nfeed = inputs if isinstance(inputs, int) else len(inputs)
             kwargs['prod'] = np.array([[fi, fj] for fi in range(nfeed) for fj in range(fi, nfeed)])
 
-        if stack is None:
+        if stack is None and prod is not None:
             stack = np.empty_like(prod, dtype=[('prod', '<u4'), ('conjugate', 'u1')])
             stack['prod'][:] = np.arange(len(prod))
             stack['conjugate'] = 0


### PR DESCRIPTION
Significant speed ups to collate products:

- Moved calculate redundancy into a Cython function.
- Moved slicing of dataset to be outside tightloop to remove implied MPI
calls.