### PR TITLE
Improve regridding speed

### DIFF
--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -68,6 +68,11 @@ def band_wiener(R, Ni, Si, y, bw):
     R_s = R.astype(np.float32)
     np.dot(y, R_s.T, out=xh)
 
+    # Calculate the start and end indices of the summation
+    start_ind = (R != 0).argmax(axis=-1).astype(np.int32)
+    end_ind = R.shape[-1] - (R[..., ::-1] != 0).argmax(axis=-1)
+    end_ind = np.where((R == 0).all(axis=-1), 0, end_ind).astype(np.int32)
+
     # Iterate through and solve noise
     for ki in range(k):
 
@@ -75,7 +80,7 @@ def band_wiener(R, Ni, Si, y, bw):
         Ni_ki = Ni[ki].astype(np.float64)
 
         # Calculate the Wiener noise weighting (i.e. inverse covariance)
-        Ci = _fast_tools._band_wiener_covariance(R, Ni_ki, bw)
+        Ci = _fast_tools._band_wiener_covariance(R, Ni_ki, start_ind, end_ind, bw)
 
         # Add on the signal covariance part
         Ci[-1] += Si


### PR DESCRIPTION
Significantly improves the speed of the regridder by restricting the
length of the inner summation when calculating the band matrix to only
the non-zero elements.