### PR TITLE
Chunked hdf5

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -105,11 +105,11 @@ class ContainerBase(memh5.BasicCont):
     def __init__(self, *args, **kwargs):
 
         # Pull out the values of needed arguments
-        axes_from = kwargs.pop('axes_from', None)
-        attrs_from = kwargs.pop('attrs_from', None)
-        dist = kwargs.pop('distributed', True)
-        comm = kwargs.pop('comm', None)
-        self.allow_chunked = kwargs.pop('allow_chunked', False)
+        axes_from = kwargs.pop("axes_from", None)
+        attrs_from = kwargs.pop("attrs_from", None)
+        dist = kwargs.pop("distributed", True)
+        comm = kwargs.pop("comm", None)
+        self.allow_chunked = kwargs.pop("allow_chunked", False)
 
         # Run base initialiser
         memh5.BasicCont.__init__(self, distributed=dist, comm=comm)
@@ -210,13 +210,13 @@ class ContainerBase(memh5.BasicCont):
         dspec = self.dataset_spec[name]
 
         # Fetch dataset properties
-        axes = dspec['axes']
-        dtype = dspec['dtype']
+        axes = dspec["axes"]
+        dtype = dspec["dtype"]
         chunks, compression, compression_opts = None, None, None
         if self.allow_chunked:
-            chunks = dspec.get('chunks', None)
-            compression = dspec.get('compression', None)
-            compression_opts = dspec.get('compression_opts', None)
+            chunks = dspec.get("chunks", None)
+            compression = dspec.get("compression", None)
+            compression_opts = dspec.get("compression_opts", None)
 
         # Get distribution properties
         dist = (
@@ -250,9 +250,16 @@ class ContainerBase(memh5.BasicCont):
             chunks = final_chunks
 
         # Create dataset
-        dset = self.create_dataset(name, shape=shape, dtype=dtype, distributed=dist,
-                                   distributed_axis=dist_axis, chunks=chunks,
-                                   compression=compression, compression_opts=compression_opts)
+        dset = self.create_dataset(
+            name,
+            shape=shape,
+            dtype=dtype,
+            distributed=dist,
+            distributed_axis=dist_axis,
+            chunks=chunks,
+            compression=compression,
+            compression_opts=compression_opts,
+        )
 
         dset.attrs["axis"] = np.array(axes)
 
@@ -532,26 +539,25 @@ class SiderealStream(ContainerBase):
     _axes = ("freq", "prod", "stack", "input", "ra")
 
     _dataset_spec = {
-        'vis': {
-            'axes': ['freq', 'stack', 'ra'],
-            'dtype': np.complex64,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (64, 256, 128)
+        "vis": {
+            "axes": ["freq", "stack", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (64, 256, 128),
         },
-
-        'vis_weight': {
-            'axes': ['freq', 'stack', 'ra'],
-            'dtype': np.float32,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (64, 256, 128)
+        "vis_weight": {
+            "axes": ["freq", "stack", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (64, 256, 128),
         },
         "input_flags": {
             "axes": ["input", "ra"],
@@ -662,26 +668,25 @@ class TimeStream(TODContainer):
     _axes = ("freq", "prod", "stack", "input", "time")
 
     _dataset_spec = {
-        'vis': {
-            'axes': ['freq', 'stack', 'time'],
-            'dtype': np.complex64,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (64, 256, 128)
+        "vis": {
+            "axes": ["freq", "stack", "time"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (64, 256, 128),
         },
-
-        'vis_weight': {
-            'axes': ['freq', 'stack', 'time'],
-            'dtype': np.float32,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (64, 256, 128)
+        "vis_weight": {
+            "axes": ["freq", "stack", "time"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (64, 256, 128),
         },
         "input_flags": {
             "axes": ["input", "time"],
@@ -851,25 +856,25 @@ class TrackBeam(ContainerBase):
     _axes = ("freq", "pol", "input", "pix")
 
     _dataset_spec = {
-        'beam': {
-            'axes': ['freq', 'pol', 'input', 'pix'],
-            'dtype': np.complex64,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (128, 2, 128, 128)
+        "beam": {
+            "axes": ["freq", "pol", "input", "pix"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (128, 2, 128, 128),
         },
-        'weight': {
-            'axes': ['freq', 'pol', 'input', 'pix'],
-            'dtype': np.float32,
-            'initialise': True,
-            'distributed': True,
-            'distributed_axis': 'freq',
-            'compression': bitshuffle.h5.H5FILTER,
-            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
-            'chunks': (128, 2, 128, 128)
+        "weight": {
+            "axes": ["freq", "pol", "input", "pix"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": bitshuffle.h5.H5FILTER,
+            "compression_opts": (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            "chunks": (128, 2, 128, 128),
         },
     }
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -542,12 +542,16 @@ class SiderealStream(ContainerBase):
             'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
             'chunks': (64, 256, 128)
         },
-        "vis_weight": {
-            "axes": ["freq", "stack", "ra"],
-            "dtype": np.float32,
-            "initialise": True,
-            "distributed": True,
-            "distributed_axis": "freq",
+
+        'vis_weight': {
+            'axes': ['freq', 'stack', 'ra'],
+            'dtype': np.float32,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'freq',
+            'compression': bitshuffle.h5.H5FILTER,
+            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            'chunks': (64, 256, 128)
         },
         "input_flags": {
             "axes": ["input", "ra"],
@@ -658,19 +662,26 @@ class TimeStream(TODContainer):
     _axes = ("freq", "prod", "stack", "input", "time")
 
     _dataset_spec = {
-        "vis": {
-            "axes": ["freq", "stack", "time"],
-            "dtype": np.complex64,
-            "initialise": True,
-            "distributed": True,
-            "distributed_axis": "freq",
+        'vis': {
+            'axes': ['freq', 'stack', 'time'],
+            'dtype': np.complex64,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'freq',
+            'compression': bitshuffle.h5.H5FILTER,
+            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            'chunks': (64, 256, 128)
         },
-        "vis_weight": {
-            "axes": ["freq", "stack", "time"],
-            "dtype": np.float32,
-            "initialise": True,
-            "distributed": True,
-            "distributed_axis": "freq",
+
+        'vis_weight': {
+            'axes': ['freq', 'stack', 'time'],
+            'dtype': np.float32,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'freq',
+            'compression': bitshuffle.h5.H5FILTER,
+            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            'chunks': (64, 256, 128)
         },
         "input_flags": {
             "axes": ["input", "time"],
@@ -850,19 +861,15 @@ class TrackBeam(ContainerBase):
             'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
             'chunks': (128, 2, 128, 128)
         },
-        "weight": {
-            "axes": ["freq", "pol", "input", "pix"],
-            "dtype": np.float32,
-            "initialise": True,
-            "distributed": True,
-            "distributed_axis": "freq",
-        },
-        "gain": {
-            "axes": ["freq", "input"],
-            "dtype": np.complex64,
-            "initialise": False,
-            "distributed": True,
-            "distributed_axis": "freq",
+        'weight': {
+            'axes': ['freq', 'pol', 'input', 'pix'],
+            'dtype': np.float32,
+            'initialise': True,
+            'distributed': True,
+            'distributed_axis': 'freq',
+            'compression': bitshuffle.h5.H5FILTER,
+            'compression_opts': (0, bitshuffle.h5.H5_COMPRESS_LZ4),
+            'chunks': (128, 2, 128, 128)
         },
     }
 


### PR DESCRIPTION
Add chunk/compression parameters to a couple of containers. By default, these will be ignored unless explicitly enabled with an option to the container initialiser.

This relies on https://github.com/radiocosmology/caput/pull/77.