### PR TITLE
fix(containers,io,task): compare strings to `basestring` from `past.builtins`.

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -40,6 +40,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from past.builtins import basestring
 # === End Python 2/3 compatibility
 
 import inspect
@@ -405,7 +406,7 @@ class TableBase(ContainerBase):
 
         dt = []
         for ci, (name, dtype) in enumerate(columns):
-            if not isinstance(name, str):
+            if not isinstance(name, basestring):
                 raise ValueError("Column %i is invalid" % ci)
             dt.append((name, dtype))
 

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -40,6 +40,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from past.builtins import basestring
 # === End Python 2/3 compatibility
 
 import os.path
@@ -58,7 +59,7 @@ def _list_of_filelists(files):
 
     for filelist in files:
 
-        if isinstance(filelist, str):
+        if isinstance(filelist, basestring):
             filelist = glob.glob(filelist)
         elif isinstance(filelist, list):
             pass
@@ -73,7 +74,7 @@ def _list_or_glob(files):
     # Take in a list of lists/glob patterns of filenames
     import glob
 
-    if isinstance(files, str):
+    if isinstance(files, basestring):
         files = sorted(glob.glob(files))
     elif isinstance(files, list):
         pass

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -15,6 +15,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from past.builtins import basestring
 # === End Python 2/3 compatibility
 
 import os
@@ -96,7 +97,7 @@ def _log_level(x):
 
     if isinstance(x, int):
         return x
-    elif isinstance(x, str) and x in level_dict:
+    elif isinstance(x, basestring) and x in level_dict:
         return level_dict[x.upper()]
     else:
         raise ValueError('Logging level %s not understood' % repr(x))


### PR DESCRIPTION
Checking if an object is an instance of `str` fails for unicode in python2.
Instead check against `basestring` class from `past.builtins`.