### PR TITLE
feat(delay): Add baseline dependent delay cut

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -28,8 +28,8 @@ class DelayFilter(task.SingleTask):
     za_cut : float
         Sine of the maximum zenith angle included in
         baseline-dependent delay filtering. Default is 1
-        which corresponds to the horizon which filters
-        out all zenith angles. Setting to zero turns off
+        which corresponds to the horizon (ie: filters
+        out all zenith angles). Setting to zero turns off
         baseline dependent cut.
     update_weight : bool
         Not implemented.

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -21,6 +21,13 @@ from ..core import containers, task, io
 class DelayFilter(task.SingleTask):
     """Remove delays less than a given threshold.
 
+    Note: The baseline-dependent delay threshold take in
+    consideration only the Y (NS) component of the baseline.
+    This is the correct thing to do for a cylindrical transit
+    telescope oriented in the NS direction. For dish type
+    reflectors, this might need to be changed to use the full
+    baseline length.
+
     Attributes
     ----------
     delay_cut : float

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -13,6 +13,7 @@ import scipy.stats as st
 from randomgen import RandomGenerator
 
 from caput import mpiarray, config
+from cora.util import units
 
 from ..core import containers, task, io
 
@@ -24,11 +25,32 @@ class DelayFilter(task.SingleTask):
     ----------
     delay_cut : float
         Delay value to filter at in seconds.
+    za_cut : float
+        Sine of the maximum zenith angle included in
+        baseline-dependent delay filtering. Default is 1
+        which corresponds to the horizon which filters
+        out all zenith angles. Setting to zero turns off
+        baseline dependent cut.
+    update_weight : bool
+        Not implemented.
+    weight_tol : float
+        Maximum weight kept in the masked data, as a fraction of
+        the largest weight in the original dataset.
     """
 
     delay_cut = config.Property(proptype=float, default=0.1)
-
+    za_cut = config.Property(proptype=float, default=1.)
     update_weight = config.Property(proptype=bool, default=False)
+    weight_tol = config.Property(proptype=float, default=1E-4)
+
+    def setup(self, telescope):
+        """Set the telescope needed to obtain baselines.
+
+        Parameters
+        ----------
+        telescope : TransitTelescope
+        """
+        self.telescope = io.get_telescope(telescope)
 
     def process(self, ss):
         """Filter out delays from a SiderealStream or TimeStream.
@@ -43,6 +65,7 @@ class DelayFilter(task.SingleTask):
         ss_filt : containers.SiderealStream
             Filtered dataset.
         """
+        tel = self.telescope
 
         if self.update_weight:
             raise NotImplemented("Weight updating is not implemented.")
@@ -54,10 +77,24 @@ class DelayFilter(task.SingleTask):
         ssv = ss.vis[:].view(np.ndarray)
         ssw = ss.weight[:].view(np.ndarray)
 
-        for lbi, bi in ss.vis[:].enumerate(axis=1):
+        ubase, uinv = np.unique(
+            tel.baselines[:, 0] + 1.0J * tel.baselines[:, 1],
+            return_inverse=True
+        )
+        ubase = ubase.view(np.float64).reshape(-1, 2)
 
-            freq_weight = np.median(ssw[:, lbi], axis=1)
-            NF = null_delay_filter(freq, self.delay_cut, freq_weight)
+        for lbi, bi in ss.vis[:].enumerate(axis=1):
+            # Y baseline
+            baseline = abs(ubase[uinv[bi], 1])
+            # In micro seconds
+            baseline_delay_cut = self.za_cut * baseline / units.c * 1E6
+            delay_cut = np.amax([baseline_delay_cut, self.delay_cut])
+
+            weight_mask = np.median(ssw[:, lbi], axis=1)
+            weight_mask = (weight_mask >
+                           (self.weight_tol*weight_mask.max())
+                           ).astype(np.float64)
+            NF = null_delay_filter(freq, delay_cut, weight_mask)
 
             ssv[:, lbi] = np.dot(NF, ssv[:, lbi])
 


### PR DESCRIPTION
BREAKING CHANGE: DelayFilter now has a `setup` method and `requires` a telescope object.
Also fix normalization bug.