### PR TITLE
fix(transform): use `time` property instead of `index_map['time']`

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -258,8 +258,10 @@ class CollateProducts(task.SingleTask):
         # Create output container
         if isinstance(ss, containers.SiderealStream):
             OutputContainer = containers.SiderealStream
+            output_kwargs = {"ra": ss.ra[:]}
         else:
             OutputContainer = containers.TimeStream
+            output_kwargs = {"time": ss.time[:]}
 
         sp = OutputContainer(
             freq=bt_freq,
@@ -271,6 +273,7 @@ class CollateProducts(task.SingleTask):
             attrs_from=ss,
             distributed=True,
             comm=ss.comm,
+            **output_kwargs,
         )
 
         # Add gain dataset.


### PR DESCRIPTION
`CollateProducts` now creates the time axis of the output `TimeStream`
container from the `time` property of the input container, so that
the time axis is defined with respect to the integration centre
instead of the integration start.