### PR TITLE
fix(transform): try to redefine stack axis using only unmasked products

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -158,6 +158,36 @@ class CollateProducts(task.SingleTask):
             .reshape(-1)
         )
 
+        # Construct the equivalent reverse_map stack for the telescope instance.
+        # Note that we identify invalid products here using an index that is the
+        # size of the stack axis.
+        def pack_product_array(arr):
+
+            nfeed = arr.shape[0]
+            nprod = (nfeed * (nfeed + 1)) // 2
+
+            ret = np.zeros(nprod, dtype=arr.dtype)
+            iout = 0
+
+            for i in range(nfeed):
+                ret[iout : (iout + nfeed - i)] = arr[i, i:]
+                iout += nfeed - i
+
+            return ret
+
+        feedmask = pack_product_array(self.telescope.feedmask)
+        self.bt_rev = np.fromiter(
+            zip(
+                np.where(
+                    feedmask,
+                    pack_product_array(self.telescope.feedmap),
+                    self.telescope.npairs,
+                ),
+                np.where(feedmask, pack_product_array(self.telescope.feedconj), 0),
+            ),
+            dtype=[("stack", "<u4"), ("conjugate", "u1")],
+        )
+
     def process(self, ss):
         """Select and reorder the products.
 
@@ -180,29 +210,9 @@ class CollateProducts(task.SingleTask):
             except ValueError:
                 return None
 
-        def pack_product_array(arr):
-
-            nfeed = arr.shape[0]
-            nprod = (nfeed * (nfeed + 1)) // 2
-
-            ret = np.zeros(nprod, dtype=arr.dtype)
-            iout = 0
-
-            for i in range(nfeed):
-                ret[iout : (iout + nfeed - i)] = arr[i, i:]
-                iout += nfeed - i
-
-            return ret
-
-        # Determine current conjugation and product map.
         match_sn = True
         if "stack" in ss.index_map:
             match_sn = ss.index_map["stack"].size == ss.index_map["prod"].size
-            ss_conj = ss.index_map["stack"]["conjugate"]
-            ss_prod = ss.index_map["prod"][ss.index_map["stack"]["prod"]]
-        else:
-            ss_conj = np.zeros(ss.vis.shape[1], dtype=np.bool)
-            ss_prod = ss.index_map["prod"]
 
         # For each input in the file, find the corresponding index in the telescope instance
         ss_keys = ss.index_map["input"][:]
@@ -240,20 +250,44 @@ class CollateProducts(task.SingleTask):
 
         bt_freq = ss.index_map["freq"][freq_ind]
 
-        # Construct the equivalent stack reverse_map for the telescope instance.  Note
-        # that we identify invalid products here using an index that is the size of the stack axis.
-        feedmask = pack_product_array(self.telescope.feedmask)
-        bt_rev = np.fromiter(
-            zip(
-                np.where(
-                    feedmask,
-                    pack_product_array(self.telescope.feedmap),
-                    self.telescope.npairs,
-                ),
-                np.where(feedmask, pack_product_array(self.telescope.feedconj), 0),
-            ),
-            dtype=[("stack", "<u4"), ("conjugate", "u1")],
-        )
+        # Determine the input product map and conjugation.
+        # If the input timestream is already stacked, then attempt to redefine
+        # its representative products so that they contain only feeds that exist
+        # and are not masked in the telescope instance.
+        if ("stack" in ss.index_map) and (
+            ss.index_map["stack"].size < ss.index_map["prod"].size
+        ):
+
+            available_prod = ss.index_map["prod"]
+            chosen_prod = available_prod[ss.index_map["stack"]["prod"]]
+            rev_stack = ss.reverse_map["stack"]
+
+            stack_new = ss.index_map["stack"].copy()
+            for sind, (ii, ij) in enumerate(chosen_prod):
+
+                bi, bj = input_ind[ii], input_ind[ij]
+                if (bi is None) or (bj is None) or not self.telescope.feedmask[bi, bj]:
+
+                    this_stack = np.flatnonzero(rev_stack["stack"] == sind)
+
+                    for ts in this_stack:
+                        tp = available_prod[ts]
+                        tbi, tbj = input_ind[tp[0]], input_ind[tp[1]]
+                        if (
+                            (tbi is not None)
+                            and (tbj is not None)
+                            and self.telescope.feedmask[tbi, tbj]
+                        ):
+                            stack_new[sind]["prod"] = ts
+                            stack_new[sind]["conjugate"] = rev_stack[ts]["conjugate"]
+                            break
+
+            ss_conj = stack_new["conjugate"]
+            ss_prod = available_prod[stack_new["prod"]]
+
+        else:
+            ss_conj = np.zeros(ss.vis.shape[1], dtype=np.bool)
+            ss_prod = ss.index_map["prod"]
 
         # Create output container
         if isinstance(ss, containers.SiderealStream):
@@ -266,7 +300,7 @@ class CollateProducts(task.SingleTask):
             input=bt_keys,
             prod=self.bt_prod,
             stack=self.bt_stack,
-            reverse_map_stack=bt_rev,
+            reverse_map_stack=self.bt_rev,
             axes_from=ss,
             attrs_from=ss,
             distributed=True,


### PR DESCRIPTION
If the timestream that is input to CollateProducts is stacked, then
attempt to redefine its stack axis so that it only contains products
consisting of inputs that are not masked in the telescope instance.

Also moves determination of `bt_rev` from `process` to `setup` since
it only depends on the telescope instance.