### PR TITLE
Jmp/hybrid beamform

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -326,8 +326,8 @@ class BeamformEW(task.SingleTask):
                 # Only need the 0th term of the irfft, equivalent to summing in
                 # then EW direction
                 m[:, 1:] *= 2.0  # Factor to include negative elements in sum below
-                bfm = np.sum(v * m, axis=1).real[:, np.newaxis, ...]
-                sb = np.sum(w * m, axis=1).real[:, np.newaxis, ...]
+                bfm = np.asarray(np.sum(v * m, axis=1)).real[:, np.newaxis, ...]
+                sb = np.asarray(np.sum(w * m, axis=1)).real[:, np.newaxis, ...]
             else:
                 bfm = np.fft.irfft(v * m, nbeam, axis=1) * nbeam
                 sb = np.fft.irfft(w * m, nbeam, axis=1) * nbeam

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -325,9 +325,9 @@ class BeamformEW(task.SingleTask):
             if self.single_beam:
                 # Only need the 0th term of the irfft, equivalent to summing in
                 # then EW direction
-                m[:, :, 1:] *= 2.0  # Factor to include negative elements in sum below
-                bfm = np.sum(v * m, axis=1).real[:, :, np.newaxis, ...]
-                sb = np.sum(w * m, axis=1).real[:, :, np.newaxis, ...]
+                m[:, 1:] *= 2.0  # Factor to include negative elements in sum below
+                bfm = np.sum(v * m, axis=1).real[:, np.newaxis, ...]
+                sb = np.sum(w * m, axis=1).real[:, np.newaxis, ...]
             else:
                 bfm = np.fft.irfft(v * m, nbeam, axis=1) * nbeam
                 sb = np.fft.irfft(w * m, nbeam, axis=1) * nbeam


### PR DESCRIPTION
Fixes two bugs for `analysis.ringmpmaker.BeamformEW` operation when the `single_beam` option is `True`

1. The intermediate ringmap and dirty beam in the frequency loop (`bfm` and `sb` respectively) had the `beam` dimension in the wrong axis.

2.  Both `bfm` and `sb` are `caput.mpiarray.MPIArray` type by default (the output of the `np.sum` operation) and have to be converted to `numpy.ndarray` before permuting their dimensions at the end of the loop (otherwise will get a `TypeError`).