### PR TITLE
feat(containers): Add input axis to weight dataset of StaticGainData.

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1196,7 +1196,7 @@ class StaticGainData(ContainerBase):
             "distributed_axis": "freq",
         },
         "weight": {
-            "axes": ["freq"],
+            "axes": ["freq", "input"],
             "dtype": np.float64,
             "initialise": False,
             "distributed": True,

--- a/draco/core/misc.py
+++ b/draco/core/misc.py
@@ -40,16 +40,16 @@ class ApplyGain(task.SingleTask):
 
     def process(self, tstream, gain):
         """Apply gains to the given timestream.
-        
+
         Smoothing the gains is not supported for SiderealStreams.
-        
+
         Parameters
         ----------
         tstream : TimeStream like or SiderealStream
             Time stream to apply gains to. The gains are applied in place.
         gain : StaticGainData, GainData or SiderealGainData
             Gains to apply.
-            
+
         Returns
         -------
         tstream : TimeStream or SiderealStream
@@ -65,7 +65,7 @@ class ApplyGain(task.SingleTask):
 
             # Get the weight array if it's there
             weight_arr = (
-                gain.weight[:] if gain.weight is not None else None
+                gain.weight[:][..., np.newaxis] if gain.weight is not None else None
             )
 
         elif isinstance(gain, (containers.GainData, containers.SiderealGainData)):
@@ -147,28 +147,29 @@ class ApplyGain(task.SingleTask):
         if self.update_weight:
             self.log.info("Applying gain to weight.")
             gweight = np.abs(gain_arr if self.inverse else inverse_gain_arr) ** 2
-            if isinstance(gain, containers.SiderealGainData):
-                # Need a prod_map for sidereal streams
-                tools.apply_gain(
-                    tstream.weight[:],
-                    gweight,
-                    out=tstream.weight[:],
-                    prod_map=tstream.prod,
-                )
-            else:
-                tools.apply_gain(tstream.weight[:], gweight, out=tstream.weight[:])
+        else:
+            gweight = np.ones(gain_arr.shape, dtype=np.float64)
 
-        # Update units if thet were specified
+        if weight_arr is not None:
+            gweight *= (weight_arr[:] > 0.0).astype(np.float64)
+
+        if isinstance(gain, containers.SiderealGainData):
+            # Need a prod_map for sidereal streams
+            tools.apply_gain(
+                tstream.weight[:],
+                gweight,
+                out=tstream.weight[:],
+                prod_map=tstream.prod,
+            )
+        else:
+            tools.apply_gain(
+                tstream.weight[:], gweight, out=tstream.weight[:],
+            )
+
+        # Update units if they were specified
         convert_units_to = gain.gain.attrs.get("convert_units_to")
         if convert_units_to is not None:
             tstream.vis.attrs["units"] = convert_units_to
-
-        # Modify the weight array according to the gain weights
-        if weight_arr is not None:
-
-            # Convert dynamic range to a binary weight and apply to data
-            gain_weight = (weight_arr[:] > 0.0).astype(np.float64)
-            tstream.weight[:] *= gain_weight[:, np.newaxis, :]
 
         return tstream
 

--- a/draco/core/misc.py
+++ b/draco/core/misc.py
@@ -65,7 +65,7 @@ class ApplyGain(task.SingleTask):
 
             # Get the weight array if it's there
             weight_arr = (
-                gain.weight[:][..., np.newaxis] if gain.weight is not None else None
+                gain.weight[:] if gain.weight is not None else None
             )
 
         elif isinstance(gain, (containers.GainData, containers.SiderealGainData)):
@@ -167,7 +167,7 @@ class ApplyGain(task.SingleTask):
         if weight_arr is not None:
 
             # Convert dynamic range to a binary weight and apply to data
-            gain_weight = (weight_arr[:] > 2.0).astype(np.float64)
+            gain_weight = (weight_arr[:] > 0.0).astype(np.float64)
             tstream.weight[:] *= gain_weight[:, np.newaxis, :]
 
         return tstream


### PR DESCRIPTION
In the pathfinder-era the weight dataset of StaticGainData
was being populated with the dynamic range of the eigenvalue
decomposition.  This is a single number per frequency.
Today we estimate the uncertainty on the gain as 1 / sigma^2
for each frequency AND input.