### PR TITLE
Hybrid map maker

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -326,8 +326,8 @@ class BeamformEW(task.SingleTask):
                 # Only need the 0th term of the irfft, equivalent to summing in
                 # then EW direction
                 m[:, 1:] *= 2.0  # Factor to include negative elements in sum below
-                bfm = np.sum(v * m, axis=1).real[:, np.newaxis, ...]
-                sb = np.sum(w * m, axis=1).real[:, np.newaxis, ...]
+                bfm = np.asarray(np.sum(v * m, axis=1)).real[:, np.newaxis, ...]
+                sb = np.asarray(np.sum(w * m, axis=1)).real[:, np.newaxis, ...]
             else:
                 bfm = np.fft.irfft(v * m, nbeam, axis=1) * nbeam
                 sb = np.fft.irfft(w * m, nbeam, axis=1) * nbeam

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -16,13 +16,6 @@ Tasks
     MakeVisGrid
     BeamformNS
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import numpy as np
 import scipy.constants
 

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1,0 +1,342 @@
+"""
+========================================================
+Map making tasks (:mod:`~draco.analysis.beamform`)
+========================================================
+
+.. currentmodule:: draco.analysis.beamform
+
+Tools for beamforming data for arrays with a cartesian layout.
+
+Tasks
+=====
+
+.. autosummary::
+    :toctree: generated/
+
+    MakeVisGrid
+    BeamformNS
+"""
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
+
+import numpy as np
+import scipy.constants
+
+from caput import config
+
+from ..core import task
+from ..core import io
+from ..util import tools
+from ..core import containers
+
+
+class MakeVisGrid(task.SingleTask):
+    """Arrange the visibilities onto a 2D grid."""
+
+    def setup(self, tel):
+        """Set the Telescope instance to use.
+
+        Parameters
+        ----------
+        tel : TransitTelescope
+        """
+        self.telescope = io.get_telescope(tel)
+
+    def process(self, sstream):
+        """Computes the ringmap.
+
+        Parameters
+        ----------
+        sstream : containers.SiderealStream
+            The input sidereal stream.
+
+        Returns
+        -------
+        rm : containers.RingMap
+        """
+
+        # Redistribute over frequency
+        sstream.redistribute("freq")
+
+        # Extract the right ascension (or calculate from timestamp)
+        ra = (
+            sstream.ra
+            if "ra" in sstream.index_map
+            else self.telescope.lsa(sstream.time)
+        )
+
+        # Construct mapping from vis array to unpacked 2D grid
+        nprod = sstream.prod.shape[0]
+        pind = np.zeros(nprod, dtype=np.int)
+        xind = np.zeros(nprod, dtype=np.int)
+        ysep = np.zeros(nprod, dtype=np.float)
+        xsep = np.zeros(nprod, dtype=np.float)
+
+        for pp, (ii, jj) in enumerate(sstream.prod):
+
+            if self.telescope.feedconj[ii, jj]:
+                ii, jj = jj, ii
+
+            # fi = self.telescope.feeds[ii]
+            # fj = self.telescope.feeds[jj]
+
+            pind[pp] = 2 * self.telescope.beamclass[ii] + self.telescope.beamclass[jj]
+            # pind[pp] = 2 * int(fi.pol == 'S') + int(fj.pol == 'S')
+            # xind[pp] = np.abs(fi.cyl - fj.cyl)
+            ysep[pp] = self.telescope.baselines[pp, 1]
+            xsep[pp] = self.telescope.baselines[pp, 0]
+            # xsep[pp] = fi.pos[0] - fj.pos[0]
+
+        abs_ysep = np.abs(ysep)
+        abs_xsep = np.abs(xsep)
+        min_ysep, max_ysep = np.percentile(abs_ysep[abs_ysep > 0.0], [0, 100])
+        min_xsep, max_xsep = np.percentile(abs_xsep[abs_xsep > 0.0], [0, 100])
+
+        yind = np.round(ysep / min_ysep).astype(np.int)
+        xind = np.round(xsep / min_xsep).astype(np.int)
+
+        grid_index = list(zip(pind, xind, yind))
+
+        # Define several variables describing the baseline configuration.
+        nfeed = int(np.round(max_ysep / min_ysep)) + 1
+        nvis_1d = 2 * nfeed - 1
+        ncyl = np.max(xind) + 1
+
+        # Define polarisation axis
+        pol = np.array([x + y for x in ["X", "Y"] for y in ["X", "Y"]])
+        vis_pos_ns = np.fft.fftfreq(nvis_1d, d=(1.0 / (nvis_1d * min_ysep)))
+        vis_pos_ew = np.arange(ncyl) * min_xsep
+
+        # Create container for output
+        grid = containers.VisGridStream(
+            pol=pol, ew=vis_pos_ew, ns=vis_pos_ns, ra=ra, axes_from=sstream
+        )
+
+        # De-reference distributed arrays outside loop to save repeated MPI calls
+        ssv = sstream.vis[:]
+        ssw = sstream.weight[:]
+        gsv = grid.vis[:]
+        gsw = grid.weight[:]
+
+        gsv[:] = 0.0
+        gsw[:] = 0.0
+
+        # Unpack visibilities into new array
+        for vis_ind, (p_ind, x_ind, y_ind) in enumerate(grid_index):
+
+            # Different behavior for intracylinder and intercylinder baselines.
+            gsv[p_ind, :, x_ind, y_ind, :] = ssv[:, vis_ind]
+            gsw[p_ind, :, x_ind, y_ind, :] = ssw[:, vis_ind]
+
+            if x_ind == 0:
+                gsv[p_ind, :, x_ind, -y_ind, :] = ssv[:, vis_ind].conj()
+                gsw[p_ind, :, x_ind, -y_ind, :] = ssw[:, vis_ind]
+
+        return grid
+
+
+class BeamformNS(task.SingleTask):
+    """A simple and quick map-maker that forms a series of beams on the meridian.
+
+    This is designed to run on data after it has been collapsed down to
+    non-redundant baselines only.
+
+    Attributes
+    ----------
+    npix : int
+        Number of map pixels in the declination dimension.  Default is 512.
+
+    span : float
+        Span of map in the declination dimension. Value of 1.0 generates a map
+        that spans from horizon-to-horizon.  Default is 1.0.
+
+    weight : string
+        How to weight the non-redundant baselines:
+            'inverse_variance' - each baseline weighted by the weight attribute
+            'natural' - each baseline weighted by its redundancy (default)
+            'uniform' - each baseline given equal weight
+            'blackman' - use a Blackman window
+            'nutall' - use a Blackman-Nutall window
+
+    scaled : bool
+        Scale the window to match the lowest frequency. This should make the
+        beams more frequency independent.
+
+    include_auto: bool
+        Include autocorrelations in the calculation.  Default is False.
+    """
+
+    npix = config.Property(proptype=int, default=512)
+    span = config.Property(proptype=float, default=1.0)
+    weight = config.enum(
+        ["uniform", "natural", "inverse_variance", "blackman", "nuttall"],
+        default="uniform",
+    )
+    scaled = config.Property(proptype=bool, default=False)
+    include_auto = config.Property(proptype=bool, default=False)
+
+    def process(self, gstream):
+        """Computes the ringmap.
+
+        Parameters
+        ----------
+        sstream : VisGridStream
+            The input stream.
+
+        Returns
+        -------
+        bf : HybridVisStream
+        """
+
+        # Redistribute over frequency
+        gstream.redistribute("freq")
+
+        gsv = gstream.vis[:]
+        gsw = gstream.weight[:].copy()
+
+        # Remove auto-correlations
+        if not self.include_auto:
+            gsw[..., 0, 0] = 0.0
+
+        # Construct phase array
+        el = self.span * np.linspace(-1.0, 1.0, self.npix)
+
+        # Create empty ring map
+        hv = containers.HybridVisStream(el=el, axes_from=gstream, attrs_from=gstream)
+        hv.redistribute("freq")
+
+        # Dereference datasets
+        hvv = hv.vis[:]
+        hvw = hv.weight[:]
+
+        nspos = gstream.index_map["ns"][:]
+        nsmax = np.abs(nspos).max()
+        freq = gstream.index_map["freq"]["centre"]
+
+        # Loop over local frequencies and fill ring map
+        for lfi, fi in gstream.vis[:].enumerate(1):
+
+            # Get the current frequency and wavelength
+            fr = freq[fi]
+            wv = scipy.constants.c * 1e-6 / fr
+
+            vpos = nspos / wv
+
+            if self.scaled:
+                wvmin = scipy.constants.c * 1e-6 / freq.min()
+                vmax = nsmax / wvmin
+            else:
+                vmax = nsmax / wv
+
+            x = 0.5 * (vpos / vmax + 1)
+            ns_weight = tools.window_generalised(x, window=self.weight)
+
+            # Create array that will be used for the inverse
+            # discrete Fourier transform in y-direction
+            phase = 2.0 * np.pi * nspos[np.newaxis, :] * el[:, np.newaxis] / wv
+            F = np.exp(-1.0j * phase) * ns_weight[np.newaxis, :]
+
+            # Calculate the hybrid visibilities
+            hvv[:, lfi] = np.dot(F, gsv[:, lfi]).transpose(1, 2, 0, 3)
+
+            # Estimate the weights assuming that the errors are all uncorrelated
+            t = np.dot(F, tools.invert_no_zero(gsw[:, lfi]) ** 0.5).transpose(
+                1, 2, 0, 3
+            )
+            hvw[:, lfi] = tools.invert_no_zero(t.real) ** 2
+
+        return hv
+
+
+class BeamformEW(task.SingleTask):
+    """Final beam forming in the EW direction.
+
+    This is designed to run on data after the NS beam forming.
+
+    Attributes
+    ----------
+    exclude_intracyl : bool
+        Exclude intracylinder baselines from the calculation.  Default is False.
+    single_beam: bool
+        Only calculate the map for the central beam. Default is False.
+    """
+
+    exclude_intracyl = config.Property(proptype=bool, default=False)
+    single_beam = config.Property(proptype=bool, default=False)
+
+    def process(self, hstream):
+        """Computes the ringmap.
+
+        Parameters
+        ----------
+        hstream : HybridVisStream
+            The input stream.
+
+        Returns
+        -------
+        rm : RingMap
+        """
+
+        # Redistribute over frequency
+        hstream.redistribute("freq")
+
+        # Create empty ring map
+        n_ew = len(hstream.index_map["ew"])
+        nbeam = 1 if self.single_beam else 2 * n_ew - 1
+
+        # Create ring map, copying over axes/attrs and add the optional datasets
+        rm = containers.RingMap(beam=nbeam, axes_from=hstream, attrs_from=hstream)
+        rm.add_dataset("rms")
+        rm.add_dataset("dirty_beam")
+
+        # Make sure ring map is distributed over frequency
+        rm.redistribute("freq")
+
+        # Estimate rms noise in the ring map by propagating estimates
+        # of the variance in the visibilities
+        # TODO: figure out what this should be
+        # rm.rms[:] = np.sqrt(np.sum(np.dot(coeff,
+        #             tools.invert_no_zero(invvar) * weight**2.0), axis=-1))
+        rm.rms[:] = 0.0
+
+        # Dereference datasets
+        hvv = hstream.vis[:]
+        hvw = hstream.weight[:]
+        rmm = rm.map[:]
+        rmb = rm.dirty_beam[:]
+
+        # Loop over local frequencies and fill ring map
+        for lfi, fi in hstream.vis[:].enumerate(axis=1):
+
+            w = hvw[:, lfi].view(np.ndarray).copy()
+
+            # Exclude the in cylinder baselines if requested (EW = 0)
+            if self.exclude_intracyl:
+                w[:, :, 0] = 0.0
+
+            # Perform  inverse fast fourier transform in x-direction
+            if self.single_beam:
+                # Only need the 0th term of the irfft, equivalent to summing in
+                # then EW direction
+                w[:, :, 1:] *= 2.0  # Factor to include negative elements in sum below
+                bfm = np.sum(hvv[:, lfi], axis=1).real[:, :, np.newaxis, ...]
+                sb = np.sum(w, axis=1).real[:, :, np.newaxis, ...]
+            else:
+                bfm = np.fft.irfft(hvv[:, lfi], nbeam, axis=1) * nbeam
+                sb = np.fft.irfft(w, nbeam, axis=1) * nbeam
+
+            # Save to container (shifting to the final axis ordering)
+            rmm[:, :, lfi] = bfm.transpose(1, 0, 3, 2)
+            rmb[:, :, lfi] = sb.transpose(1, 0, 3, 2)
+
+        return rm
+
+
+class RingMapMaker(task.group_tasks(MakeVisGrid, BeamformNS, BeamformEW)):
+    """Make a ringmap from the data."""
+
+    pass

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -325,9 +325,9 @@ class BeamformEW(task.SingleTask):
             if self.single_beam:
                 # Only need the 0th term of the irfft, equivalent to summing in
                 # then EW direction
-                m[:, :, 1:] *= 2.0  # Factor to include negative elements in sum below
-                bfm = np.sum(v * m, axis=1).real[:, :, np.newaxis, ...]
-                sb = np.sum(w * m, axis=1).real[:, :, np.newaxis, ...]
+                m[:, 1:] *= 2.0  # Factor to include negative elements in sum below
+                bfm = np.sum(v * m, axis=1).real[:, np.newaxis, ...]
+                sb = np.sum(w * m, axis=1).real[:, np.newaxis, ...]
             else:
                 bfm = np.fft.irfft(v * m, nbeam, axis=1) * nbeam
                 sb = np.fft.irfft(w * m, nbeam, axis=1) * nbeam

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1304,10 +1304,195 @@ class KLModes(SVDModes):
     pass
 
 
-class CommonModeGainData(TODContainer):
-    """Parallel container for holding gain data common to all inputs."""
+class VisGridStream(ContainerBase):
+    """Visibilities gridded into a 2D array.
 
-    _axes = ("freq",)
+    Only makes sense for an array which is a cartesian grid.
+    """
+
+    _axes = ("pol", "freq", "ew", "ns", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["pol", "freq", "ew", "ns", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "vis_weight": {
+            "axes": ["pol", "freq", "ew", "ns", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+
+    @property
+    def weight(self):
+        return self.datasets["vis_weight"]
+
+
+class HybridVisStream(ContainerBase):
+    """Visibilities gridded into a 2D array.
+
+    Only makes sense for an array which is a cartesian grid.
+    """
+
+    _axes = ("pol", "freq", "ew", "el", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["pol", "freq", "ew", "el", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "vis_weight": {
+            "axes": ["pol", "freq", "ew", "el", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+
+    @property
+    def weight(self):
+        return self.datasets["vis_weight"]
+
+
+class HybridVisMModes(ContainerBase):
+    """Visibilities gridded into a 2D array.
+
+    Only makes sense for an array which is a cartesian grid.
+    """
+
+    _axes = ("pol", "freq", "ew", "el", "m", "msign")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["m", "msign", "pol", "freq", "ew", "el"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "vis_weight": {
+            "axes": ["m", "msign", "pol", "freq", "ew", "el"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    def __init__(self, mmax=None, *args, **kwargs):
+
+        # Set up axes from passed arguments
+        if mmax is not None:
+            kwargs["m"] = mmax + 1
+
+        # Ensure the sign axis is set correctly
+        kwargs["msign"] = np.array(["+", "-"])
+
+        super(HybridVisMModes, self).__init__(*args, **kwargs)
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+
+    @property
+    def weight(self):
+        return self.datasets["vis_weight"]
+
+
+class RingMap(ContainerBase):
+    """Container for holding multifrequency ring maps.
+
+    The maps are packed in format `[freq, pol, ra, EW beam, el]` where
+    the polarisations are Stokes I, Q, U and V.
+
+    Parameters
+    ----------
+    nside : int
+        The nside of the Healpix maps.
+    polarisation : bool, optional
+        If `True` all Stokes parameters are stored, if `False` only Stokes I is
+        stored.
+    """
+
+    _axes = ("freq", "pol", "ra", "beam", "el")
+
+    _dataset_spec = {
+        "map": {
+            "axes": ["beam", "pol", "freq", "ra", "el"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "dirty_beam": {
+            "axes": ["beam", "pol", "freq", "ra", "el"],
+            "dtype": np.float64,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "rms": {
+            "axes": ["pol", "freq", "ra"],
+            "dtype": np.float64,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+
+        super(RingMap, self).__init__(*args, **kwargs)
+
+    @property
+    def freq(self):
+        return self.index_map["freq"]
+
+    @property
+    def pol(self):
+        return self.index_map["pol"]
+
+    @property
+    def ra(self):
+        return self.index_map["ra"]
+
+    @property
+    def el(self):
+        return self.index_map["el"]
+
+    @property
+    def map(self):
+        return self.datasets["map"]
+
+    @property
+    def rms(self):
+        return self.datasets["rms"]
+
+    @property
+    def dirty_beam(self):
+        return self.datasets["dirty_beam"]
+
+
+class CommonModeGainData(FreqContainer, TODContainer):
+    """Parallel container for holding gain data common to all inputs."""
 
     _dataset_spec = {
         "gain": {
@@ -1336,10 +1521,6 @@ class CommonModeGainData(TODContainer):
             return self.datasets["weight"]
         except KeyError:
             return None
-
-    @property
-    def freq(self):
-        return self.index_map["freq"]["centre"]
 
 
 class CommonModeSiderealGainData(FreqContainer, SiderealContainer):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1319,6 +1319,12 @@ class VisGridStream(FreqContainer, SiderealContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
+        "redundancy": {
+            "axes": ["pol", "ew", "ns", "ra"],
+            "dtype": np.int32,
+            "initialise": True,
+            "distributed": False,
+        },
     }
 
     @property
@@ -1329,6 +1335,9 @@ class VisGridStream(FreqContainer, SiderealContainer):
     def weight(self):
         return self.datasets["vis_weight"]
 
+    @property
+    def redundancy(self):
+        return self.datasets["redundancy"]
 
 
 class HybridVisStream(FreqContainer, SiderealContainer):
@@ -1348,8 +1357,15 @@ class HybridVisStream(FreqContainer, SiderealContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
-        "vis_weight": {
+        "dirty_beam": {
             "axes": ["pol", "freq", "ew", "el", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "vis_weight": {
+            "axes": ["pol", "freq", "ew", "ra"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
@@ -1365,16 +1381,20 @@ class HybridVisStream(FreqContainer, SiderealContainer):
     def weight(self):
         return self.datasets["vis_weight"]
 
+    @property
+    def dirty_beam(self):
+        """This isn't useful at this stage, but it's needed to propagate onward."""
+        return self.datasets["dirty_beam"]
 
 
-class HybridVisMModes(FreqContainer):
+class HybridVisMModes(FreqContainer, MContainer):
     """Visibilities beamformed in the NS direction and m-mode transformed in RA.
 
     This container has visibilities beam formed only in the NS direction to give a
     grid in elevation.
     """
 
-    _axes = ("pol", "freq", "ew", "el")
+    _axes = ("pol", "ew", "el")
 
     _dataset_spec = {
         "vis": {
@@ -1385,7 +1405,7 @@ class HybridVisMModes(FreqContainer):
             "distributed_axis": "freq",
         },
         "vis_weight": {
-            "axes": ["m", "msign", "pol", "freq", "ew", "el"],
+            "axes": ["m", "msign", "pol", "freq", "ew"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
@@ -1427,6 +1447,13 @@ class RingMap(FreqContainer, SiderealContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
+        "weight": {
+            "axes": ["pol", "freq", "ra"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
         "dirty_beam": {
             "axes": ["beam", "pol", "freq", "ra", "el"],
             "dtype": np.float64,
@@ -1458,6 +1485,10 @@ class RingMap(FreqContainer, SiderealContainer):
     @property
     def rms(self):
         return self.datasets["rms"]
+
+    @property
+    def weight(self):
+        return self.datasets["weight"]
 
     @property
     def dirty_beam(self):

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -538,3 +538,35 @@ class Delete(SingleTask):
         gc.collect()
 
         return None
+
+
+def group_tasks(*tasks):
+    """Create a Task that groups a bunch of tasks together.
+
+    This method creates a class that inherits from all the subtasks, and
+    calls each `process` method in sequence, passing the output of one to the
+    input of the next.
+
+    This should be used like:
+
+    >>> class SuperTask(group_tasks(SubTask1, SubTask2)):
+    >>>     pass
+
+    At the moment if the ensemble has more than one setup method, the
+    SuperTask will need to implement an override that correctly calls each.
+    """
+
+    class TaskGroup(*tasks):
+
+        # TODO: figure out how to make the setup work at the moment it just picks the first in MRO
+        # def setup(self, x): pass
+
+        def process(self, x):
+
+            for t in tasks:
+                self.log.debug("Calling process for subtask %s", t.__name__)
+                x = t.process(self, x)
+
+            return x
+
+    return TaskGroup

--- a/draco/util/tools.py
+++ b/draco/util/tools.py
@@ -520,3 +520,39 @@ def baseline_vector(index_map, telescope):
         #    bvec_m[:, vi] *= -1.
 
     return bvec_m
+
+
+def window_generalised(x, window="nuttall"):
+    """A generalised high-order window at arbitrary locations.
+
+    Parameters
+    ----------
+    x : np.ndarray[n]
+        Location to evaluate at. Values outside the range 0 to 1 are zero.
+    window : one of {'nuttall', 'blackman_nuttall', 'blackman_harris'}
+        Type of window function to return.
+
+    Returns
+    -------
+    w : np.ndarray[n]
+        Window function.
+    """
+
+    a_table = {
+        "uniform": np.array([1, 0, 0, 0]),
+        "hanning": np.array([0.5, -0.5, 0, 0]),
+        "hamming": np.array([0.53836, -0.46164, 0, 0]),
+        "blackman": np.array([0.42, -0.5, 0.08, 0]),
+        "nuttall": np.array([0.355768, -0.487396, 0.144232, -0.012604]),
+        "blackman_nuttall": np.array([0.3635819, -0.4891775, 0.1365995, -0.0106411]),
+        "blackman_harris": np.array([0.35875, -0.48829, 0.14128, -0.01168]),
+    }
+
+    a = a_table[window]
+
+    t = 2 * np.pi * np.arange(4)[:, np.newaxis] * x[np.newaxis, :]
+
+    w = (a[:, np.newaxis] * np.cos(t)).sum(axis=0)
+    w = np.where((x >= 0) & (x <= 1), w, 0)
+
+    return w

--- a/draco/util/tools.py
+++ b/draco/util/tools.py
@@ -540,6 +540,7 @@ def window_generalised(x, window="nuttall"):
 
     a_table = {
         "uniform": np.array([1, 0, 0, 0]),
+        "hann": np.array([0.5, -0.5, 0, 0]),
         "hanning": np.array([0.5, -0.5, 0, 0]),
         "hamming": np.array([0.53836, -0.46164, 0, 0]),
         "blackman": np.array([0.42, -0.5, 0.08, 0]),


### PR DESCRIPTION
This is now ready for review. There's a few broader fixes in here, but the biggest change is the introduction of the componentised ring map maker.

I have tested this against the current ring map maker and it gives nearly identical maps, that differ at the 10^-3 level. Here is a comparison of the maps using uniform weighting:
<img width="744" alt="Unknown-33" src="https://user-images.githubusercontent.com/695206/103842137-0bc20a00-504a-11eb-8551-c8f3886c1469.png">
The top panel is the map from the new map maker (from -10 Jy to 10 Jy), the middle panel is the difference between the old and new maps with the colour scale multiplied by 1000x (i.e. it's from +/- 10 mJy). The third is the difference if I apply a ~10^-3 level scale to the new map to get them to match better.

This is the same comparison but for natural weighting
<img width="744" alt="Unknown-34" src="https://user-images.githubusercontent.com/695206/103842269-6491a280-504a-11eb-944d-484ca90bba29.png">

One obvious question is: why is there any difference at all? Essentially it all comes down to how the different maps are renormalised for missing baselines. The original map maker constructs the weights for all baselines initially, and normalises by the sum of all the weights to guarantee that the output units are faithfully Jy / beam (i.e. if you take the pixel containing CygA it will have the value of the flux of CygA). The new map maker first constructs a grid of NS beams, and each column of EW visibilities is normalised independently. This guarantees that the hybrid visibilities (i.e. localised NS beam, fourier mode EW) which come out of the BeamformNS stage are in units of Jy. However, because the EW transform is done separately it's tough (and not clearly desirable) for this to give each cylinder separation the same relative weighting that they are given in the old map maker.

If the missing NS baselines were identical for each cylinder separation the map makers would give the same result. However, when the missing NS baselines are different the map makers will give different results. The biggest thing which breaks this is the masking of the autocorrelations, which is why the differences are at the ~1/1024 level.


Given that we never really sorted out the most theoretically desirable scheme for the old map maker, I don't think this difference is very problematic, but it would be good to hear if any one else (e.g. @ashill and @ssiegelx who aren't tagged for review) can think of any objections.
