### PR TITLE
fix(SVDModeProject): don't take attrs from MModes

### DIFF
--- a/draco/analysis/fgfilter.py
+++ b/draco/analysis/fgfilter.py
@@ -80,7 +80,7 @@ class SVDModeProject(_ProjectFilterBase):
         tel = bt.telescope
 
         svdmodes = containers.SVDModes(
-            mode=bt.ndofmax, axes_from=mmodes, attrs_from=mmodes
+            mode=bt.ndofmax, axes_from=mmodes
         )
         svdmodes.vis[:] = 0.0
 
@@ -127,7 +127,6 @@ class SVDModeProject(_ProjectFilterBase):
             freq=freqmap,
             prod=tel.uniquepairs,
             input=feed_index,
-            attrs_from=svdmodes,
             axes_from=svdmodes,
         )
         mmodes.redistribute("m")


### PR DESCRIPTION
In `analysis.fgfilter.SVDModeProject`, when the new `SVDModes` container is initialized, we don't want to inherit attributes from the parent `MModes` container: if we do, then the `vis` dataset in `SVDModes` will have `axes` equal to `["m", "msign", "freq", "stack"]`, when it should have `["m", "mode"]`. The same applies when we do a backwards projection from SVD modes into m-modes.