### PR TITLE
(fix): Update randomgen API

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -10,7 +10,13 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 import numpy as np
 import scipy.linalg as la
 import scipy.stats as st
-from randomgen import RandomGenerator
+
+try:
+    # For backwards compatibility
+    from randomgen import RandomGenerator
+except ImportError:
+    from randomgen import Generator as RandomGenerator
+
 
 from caput import mpiarray, config
 from cora.util import units


### PR DESCRIPTION
In version 1.18.0 randomgen changed the API from:
```from randomgen import RandomGenerator```
to
```from randomgen import Generator```