### PR TITLE
Fix crash print

### DIFF
--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -138,11 +138,8 @@ class SiderealGrouper(task.SingleTask):
             Returns the timestream of the final sidereal day if it's long
             enough, otherwise returns :obj:`None`.
         """
-
         # If we are here there is no more data coming, we just need to process any remaining data
-        tstream_all = self._process_current_lsd()
-
-        return tstream_all
+        return self._process_current_lsd() if self._timestream_list else None
 
     def _process_current_lsd(self):
         # Combine the current set of files into a timestream

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -577,7 +577,7 @@ class MModeInverseTransform(task.SingleTask):
 
         Returns
         -------
-        sstream : containers.SiderealStream 
+        sstream : containers.SiderealStream
             The output sidereal stream.
         """
         # NOTE: If n_time is smaller than Nyquist sampling the m-mode axis then
@@ -623,10 +623,8 @@ def _unpack_marray(mmodes, n=None):
     shape = mmodes.shape[2:]
     mmax_plus = mmodes.shape[0] - 1
     if (mmodes[mmax_plus, 1, ...].flatten() == 0).all():
-        print("Had an even number os samples originally")
         mmax_minus = mmax_plus - 1
     else:
-        print("Had an odd number of samples originally")
         mmax_minus = mmax_plus
 
     if n is None:


### PR DESCRIPTION
Fix a crash when the SiderealGrouper runs with no inputs and remove some useless print statements.