### PR TITLE
fix(SingleTask): use memh5 history for metadata

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -401,10 +401,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
             # add metadata to output
             metadata = {"versions": self.versions, "config": self.pipeline_config}
             for key, value in metadata.items():
-                # NOTE: this will overwrite any existing metadata keys. This is probably the right
-                # thing to do for now, but really we should be using the `history` functionality for
-                # this.
-                output.attrs[key] = value
+                output.add_history(key, value)
 
             # Create a tag for the output file name
             tag = output.attrs["tag"] if "tag" in output.attrs else self._count


### PR DESCRIPTION
Instead of adding metadata as attributes to BasicCont, use the history
feature.

I didn't expect this to pass, but it did, because I moved all the tests that directly read h5 files into caput.
~Depends on~ Actually doesn't depend on https://github.com/radiocosmology/caput/pull/128 ...but looks nicer with it.

Fixes #88