### PR TITLE
fix(SetMPILogging): don't override root log level

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -131,12 +131,9 @@ class SetMPILogging(pipeline.TaskBase):
         filt = MPILogFilter(level_all=self.level_all, level_rank0=self.level_rank0)
 
         # This uses the fact that caput.pipeline.Manager has already
-        # attempted to set up the logging. We just override the level, and
-        # insert our custom filter
+        # attempted to set up the logging. We just insert our custom filter
         root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
         ch = root_logger.handlers[0]
-        ch.setLevel(logging.DEBUG)
         ch.addFilter(filt)
 
         formatter = logging.Formatter(

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -154,7 +154,9 @@ class LoggedTask(pipeline.TaskBase):
     def __init__(self):
 
         # Get the logger for this task
-        self._log = logging.getLogger("%s.%s" % (__name__, self.__class__.__name__))
+        self._log = logging.getLogger(
+            "%s.%s" % (self.__module__, self.__class__.__name__)
+        )
 
         # Set the log level for this task if specified
         if self.log_level is not None:


### PR DESCRIPTION
After https://github.com/radiocosmology/caput/pull/129, this was found to just break logging by overriding the root log level.