### PR TITLE
Jmp/hybrid ps

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -286,6 +286,8 @@ class DelayTransformGibbs(task.SingleTask):
     ----------
     nsamp : int, optional
         The number of Gibbs samples to draw.
+    window : bool, optional
+        Apply a Nuttall apodisation function. Default is True.
     freq_zero : float, optional
         The physical frequency (in MHz) of the *zero* channel. That is the DC
         channel coming out of the F-engine. If not specified, use the first
@@ -309,6 +311,7 @@ class DelayTransformGibbs(task.SingleTask):
     """
 
     nsamp = config.Property(proptype=int, default=20)
+    window = config.Property(proptype=bool, default=True)
     freq_zero = config.Property(proptype=float, default=None)
     freq_spacing = config.Property(proptype=float, default=None)
     nfreq = config.Property(proptype=int, default=None)
@@ -444,7 +447,7 @@ class DelayTransformGibbs(task.SingleTask):
 
                 spec, dtransform = delay_spectrum_gibbs(
                     data, ndelay, weight, initial_S, fsel=channel_ind, niter=self.nsamp,
-                    real_valued_output=self.real_valued_output)
+                    real_valued_output=self.real_valued_output, window=self.window)
 
                 # Take an average over the last half of the delay transform samples
                 # (presuming that removes the burn-in)

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -617,7 +617,7 @@ def fourier_matrix_c2c(N, fsel=None):
     fa = fa[:, np.newaxis]
     ta = np.arange(N)[np.newaxis, :]
 
-    return np.exp(-2 * np.pi * ta * fa / N)
+    return np.exp(-2.0j * np.pi * ta * fa / N)
 
 
 def fourier_matrix_c2r(N, fsel=None):
@@ -795,8 +795,9 @@ def delay_spectrum_gibbs(data, N, Ni, initial_S, window=True, fsel=None, niter=2
 
         S_hat = d.var(axis=1)
 
-        df = d.shape[1]
-        chi2 = rng.chisquare(df, size=d.shape[0])
+        df = d.shape[1] if real_valued_output else 2 * d.shape[1]
+        alpha = 1. if real_valued_output else 2.
+        chi2 = alpha * rng.chisquare(df, size=d.shape[0])
 
         S_samp = S_hat * df / chi2
 

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -388,10 +388,11 @@ class DelayTransformGibbs(task.SingleTask):
         slice_before = (np.s_[:],) * dist_axis_index
 
         # Figure out index ordering to have (freq, avg_index) in the last two dimensions
-        local_shape_transposed = np.array(ss.vis.local_shape) # Will need this to reshape out later
-        local_shape_transposed[dist_axis_index] = -1 # assumes dist_axis is not "freq"
+        local_shape_transposed = np.array(ss.vis.shape) # Will need this to reshape out later
         # Dimension of the input's frequency and avg_axis axes
-        Nfreq_cont, Navg = local_shape_transposed[[freq_axis_index, avg_axis_index]]
+        Nfreq_cont, Navg, Ndist = local_shape_transposed[[freq_axis_index,
+            avg_axis_index, dist_axis_index]]
+        local_shape_transposed[dist_axis_index] = -1 # assumes dist_axis is not "freq"
         local_shape_transposed[freq_axis_index] = ndelay # input freq and output delay on same axis
         transposed_indices = np.arange(len(local_shape_transposed))
         # index ordering to have frequency/delay on the second-to-last dimension
@@ -404,6 +405,8 @@ class DelayTransformGibbs(task.SingleTask):
 
         # Iterate over dist_axis and use the Gibbs sampler to estimate the delay transform
         for lbi, bi in dtransform_cont.vis[:].enumerate(axis=dist_axis_index):
+
+            self.log.debug("Delay transforming %s element %i/%i", dist_axis, bi, Ndist)
 
             # Get local selections, transpose to have (freq, avg_index) in the last two axes,
             # and reshape to have a 3D array with (freq, avg_index) in the last two axes

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -422,7 +422,7 @@ def fourier_matrix_c2r(N, fsel=None):
     Fr = np.zeros((N, 2 * fa.shape[1]), dtype=np.float64)
 
     Fr[:, 0::2] = np.cos(2 * np.pi * ta * fa / N) * mul
-    Fr[:, 1::2] = -np.sin(2 * np.pi * ta * fa / N) * mul
+    Fr[:, 1::2] = np.sin(2 * np.pi * ta * fa / N) * mul
 
     return Fr
 

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -16,6 +16,7 @@ from caput import mpiarray, config
 from cora.util import units
 
 from ..core import containers, task, io
+from ..util import tools
 
 
 class DelayFilter(task.SingleTask):
@@ -454,8 +455,9 @@ class DelayTransformGibbs(task.SingleTask):
                 dtransform_av = np.mean(dtransform[-(self.nsamp // 2) :], axis=0)
                 spec_av = np.mean(spec[-(self.nsamp // 2) :], axis=0)
                 dtransform_local[i] = np.fft.fftshift(dtransform_av, axes=0)
-                # For now, weights are just the variance of the dtransform along avg_axis
-                dtransform_weight_local[i] = np.var(dtransform_local[i], axis=-1)[:, np.newaxis]
+                # For now, weights are just the inv variance of the dtransform along avg_axis
+                dtransform_weight_local[i] = tools.invert_no_zero(np.var(dtransform_local[i],
+                    axis=-1))[:, np.newaxis]
 
             # Reshape, transpose to original form and save
             dtransform_cont.vis[slice_before + (np.s_[bi:bi+1],)] = dtransform_local.reshape(

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -448,8 +448,8 @@ class DelayTransformGibbs(task.SingleTask):
 
                 # Take an average over the last half of the delay transform samples
                 # (presuming that removes the burn-in)
-                dtransform_av = np.median(dtransform[-(self.nsamp // 2) :], axis=0)
-                spec_av = np.median(spec[-(self.nsamp // 2) :], axis=0)
+                dtransform_av = np.mean(dtransform[-(self.nsamp // 2) :], axis=0)
+                spec_av = np.mean(spec[-(self.nsamp // 2) :], axis=0)
                 dtransform_local[i] = np.fft.fftshift(dtransform_av, axes=0)
                 # For now, weights are just the variance of the dtransform along avg_axis
                 dtransform_weight_local[i] = np.var(dtransform_local[i], axis=-1)[:, np.newaxis]

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -202,7 +202,7 @@ class BeamformNS(task.SingleTask):
         el = self.span * np.linspace(-1.0, 1.0, self.npix)
 
         # Create empty ring map
-        hv = containers.HybridVisStream(el=el, axes_from=gstream, attrs_from=gstream)
+        hv = containers.HybridVisStream(el=el, axes_from=gstream)
         hv.redistribute("freq")
 
         # Dereference datasets

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -518,7 +518,7 @@ class MModeTransform(task.SingleTask):
 
         Returns
         -------
-        mmodes : containers.MModes
+        mmodes : containers.MModes, HybridVisMModes or HybridVisDelayMModes
         """
 
         contmap = {

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1158,6 +1158,11 @@ class HybridVisStream(ContainerBase):
     def weight(self):
         return self.datasets["vis_weight"]
 
+    @property
+    def freq(self):
+        return self.index_map["freq"]["centre"]
+
+
 class HybridVisDelayStream(ContainerBase):
     """Container for delay transform of beams on the meridian.
 
@@ -1190,6 +1195,10 @@ class HybridVisDelayStream(ContainerBase):
     @property
     def weight(self):
         return self.datasets["vis_weight"]
+
+    @property
+    def delay(self):
+        return self.datasets["delay"]
 
 
 class HybridVisMModes(ContainerBase):
@@ -1504,6 +1513,40 @@ class DelaySpectrum(ContainerBase):
     @property
     def spectrum(self):
         return self.datasets["spectrum"]
+
+
+class DelayTransform(ContainerBase):
+    """Container for a delay transform of SiderealStream.
+    """
+
+    _axes = ("delay", "stack", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["delay", "stack", "ra"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "stack",
+        },
+        "weight": {
+            "axes": ["delay", "stack", "ra"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "stack",
+        }
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+    @property
+    def weight(self):
+        return self.datasets["weight"]
+    @property
+    def delay(self):
+        return self.datasets["delay"]
 
 
 class Powerspectrum2D(ContainerBase):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1198,7 +1198,7 @@ class HybridVisDelayStream(ContainerBase):
 
     @property
     def delay(self):
-        return self.datasets["delay"]
+        return self.index_map["delay"]
 
 
 class HybridVisMModes(ContainerBase):
@@ -1546,7 +1546,7 @@ class DelayTransform(ContainerBase):
         return self.datasets["weight"]
     @property
     def delay(self):
-        return self.datasets["delay"]
+        return self.index_map["delay"]
 
 
 class Powerspectrum2D(ContainerBase):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1549,6 +1549,74 @@ class DelayTransform(ContainerBase):
         return self.index_map["delay"]
 
 
+class VisI(ContainerBase):
+    """Container for a Stokes I.
+    """
+
+    _axes = ("baseline", "freq", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["baseline", "freq", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "weight": {
+            "axes": ["baseline", "freq", "ra"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        }
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+    @property
+    def weight(self):
+        return self.datasets["weight"]
+    @property
+    def freq(self):
+        return self.index_map["freq"]["centre"]
+
+
+class DelayTransformVisI(ContainerBase):
+    """Container for a delay transform of VisI data.
+    """
+
+    _axes = ("baseline", "delay", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["baseline", "delay", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        },
+        "weight": {
+            "axes": ["baseline", "delay", "ra"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        }
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+    @property
+    def weight(self):
+        return self.datasets["weight"]
+    @property
+    def delay(self):
+        return self.index_map["delay"]
+
+
 class Powerspectrum2D(ContainerBase):
     """Container for a 2D cartesian power spectrum.
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1126,7 +1126,7 @@ class VisGridStream(ContainerBase):
 
 
 class HybridVisStream(ContainerBase):
-    """Visibilities gridded into a 2D array.
+    """Container for beams on the meridian.
 
     Only makes sense for an array which is a cartesian grid.
     """
@@ -1158,9 +1158,42 @@ class HybridVisStream(ContainerBase):
     def weight(self):
         return self.datasets["vis_weight"]
 
+class HybridVisDelayStream(ContainerBase):
+    """Container for delay transform of beams on the meridian.
+
+    Only makes sense for an array which is a cartesian grid.
+    """
+
+    _axes = ("pol", "delay", "ew", "el", "ra")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["pol", "delay", "ew", "el", "ra"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "delay",
+        },
+        "vis_weight": {
+            "axes": ["pol", "delay", "ew", "el", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "delay",
+        },
+    }
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+
+    @property
+    def weight(self):
+        return self.datasets["vis_weight"]
+
 
 class HybridVisMModes(ContainerBase):
-    """Visibilities gridded into a 2D array.
+    """Container for Mmodes of beams on the meridian.
 
     Only makes sense for an array which is a cartesian grid.
     """
@@ -1194,6 +1227,50 @@ class HybridVisMModes(ContainerBase):
         kwargs["msign"] = np.array(["+", "-"])
 
         super(HybridVisMModes, self).__init__(*args, **kwargs)
+
+    @property
+    def vis(self):
+        return self.datasets["vis"]
+
+    @property
+    def weight(self):
+        return self.datasets["vis_weight"]
+
+class HybridVisDelayMModes(ContainerBase):
+    """Container for Mmodes of beams on the meridian after delay transform.
+
+    Only makes sense for an array which is a cartesian grid.
+    """
+
+    _axes = ("pol", "delay", "ew", "el", "m", "msign")
+
+    _dataset_spec = {
+        "vis": {
+            "axes": ["m", "msign", "pol", "delay", "ew", "el"],
+            "dtype": np.complex64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "delay",
+        },
+        "vis_weight": {
+            "axes": ["m", "msign", "pol", "delay", "ew", "el"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "delay",
+        },
+    }
+
+    def __init__(self, mmax=None, *args, **kwargs):
+
+        # Set up axes from passed arguments
+        if mmax is not None:
+            kwargs["m"] = mmax + 1
+
+        # Ensure the sign axis is set correctly
+        kwargs["msign"] = np.array(["+", "-"])
+
+        super(HybridVisDelayMModes, self).__init__(*args, **kwargs)
 
     @property
     def vis(self):


### PR DESCRIPTION
This PR solves [chime-experiment/Pipeline/issues/44](https://github.com/chime-experiment/Pipeline/issues/44) by:

- Modifying the Gibbs-sampling based power spectrum estimation function `delay.delay_spectrum_gibbs` to return both the power spectrum and delay transform, and to allow complex valued delay transforms.
- Creating a new task `delay.DelayTransformGibbs` for delay transform estimation estimation that accepts different containers as input. Currently the function accepts `SiderealStream` and `HybridVisStream` containers as inputs. To add a new input type, update the container information dictionary `contmap`.

Some comments:
- The way `delay.DelayTransformGibbs` works requires that allowed input containers are listed in `contmap`. One way to make `DelayTransformGibbs` accept any input without relying on `contmap` js to convert it to a function (instead of a task).
- The weight dataset of the delay transform output container is calculated from the inverse of the delay transform variance along the averaging axis. Is this the correct way to assign weights to the estimated delay transform?
