### PR TITLE
Fix Fill of Initial Values in SVD EM Routine

### DIFF
--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -1,5 +1,4 @@
-"""A set of tasks for SVD filtering the m-modes.
-"""
+"""A set of tasks for SVD filtering the m-modes."""
 # === Start Python 2/3 compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614


### PR DESCRIPTION
In the `svd_em` routine, masked values in the matrix to SVD are initially filled with the median value of the entire matrix (including the masked values). This fix makes it so that the initial fill uses the median of only the unmasked values in the matrix.