### PR TITLE
fix(containers): fix copy for non-distributed data

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -220,9 +220,7 @@ class ContainerBase(memh5.BasicCont):
             compression_opts = dspec.get("compression_opts", None)
 
         # Get distribution properties
-        dist = (
-            dspec["distributed"] if "distributed" in dspec else self._data._distributed
-        )
+        dist = self.distributed and dspec.get("distributed", True)
         shape = ()
 
         # Check that all the specified axes are defined, and fetch their lengths
@@ -413,7 +411,13 @@ class ContainerBase(memh5.BasicCont):
         copy : subclass of ContainerBase
             The copied container.
         """
-        new_cont = self.__class__(attrs_from=self, axes_from=self, skip_datasets=True)
+        new_cont = self.__class__(
+            attrs_from=self,
+            axes_from=self,
+            skip_datasets=True,
+            distributed=self.distributed,
+            comm=self.comm,
+        )
 
         # Loop over datasets that exist in the source and either add a view of
         # the source dataset, or perform a full copy


### PR DESCRIPTION
This commit passes along the distributed and comm properties of
the container when instantiating its copy.  It also prevents
distributed datasets in a non-distributed container.