### PR TITLE
Delay filter/estimator fixes and BlendStack task

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -303,6 +303,9 @@ def stokes_I(sstream, tel):
     # TODO: this should be updated when driftscan gains a concept of polarisation
     ssv = sstream.vis[:]
     ssw = sstream.weight[:]
+
+    # Cache beamclass as it's regenerated every call
+    beamclass = tel.beamclass[:]
     for ii, ui in enumerate(uinv):
 
         # Skip if not all polarisations were included
@@ -310,7 +313,7 @@ def stokes_I(sstream, tel):
             continue
 
         fi, fj = tel.uniquepairs[ii]
-        bi, bj = tel.beamclass[fi], tel.beamclass[fj]
+        bi, bj = beamclass[fi], beamclass[fj]
 
         upi = tel.feedmap[fi, fj]
 

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -286,12 +286,14 @@ def stokes_I(sstream, tel):
     baselines : np.ndarray[nbase, 2]
     """
 
+    # Construct a complex number representing each baseline (used for determining
+    # unique baselines).
+    # NOTE: due to floating point precision, some baselines don't get matched as having
+    # the same lengths. To get around this, round all separations to 0.1 mm precision
+    bl_round = np.around(tel.baselines[:, 0] + 1.0j * tel.baselines[:, 1], 4)
+
     # ==== Unpack into Stokes I
-    ubase, uinv, ucount = np.unique(
-        tel.baselines[:, 0] + 1.0j * tel.baselines[:, 1],
-        return_inverse=True,
-        return_counts=True,
-    )
+    ubase, uinv, ucount = np.unique(bl_round, return_inverse=True, return_counts=True)
     ubase = ubase.view(np.float64).reshape(-1, 2)
     nbase = ubase.shape[0]
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1060,3 +1060,123 @@ def destripe(x, w, axis=1):
     bsel = tuple(bsel)
 
     return x - stripe[bsel]
+
+
+class BlendStack(task.SingleTask):
+    """Mix a small amount of a stack into data to regularise RFI gaps.
+
+    This is designed to mix in a small amount of a stack into a day of data (which
+    will have RFI masked gaps) to attempt to regularise operations which struggle to
+    deal with time variable masks, e.g. `DelaySpectrumEstimator`.
+
+    Attribute
+    ---------
+    frac : float, optional
+        The relative weight to give the stack in the average. This multiplies the
+        weights already in the stack, and so it should be remembered that these may
+        already be significantly higher than the single day weights.
+    match_median : bool, optional
+        Estimate the median in the time/RA direction from the common samples and use
+        this to match any quasi time-independent bias of the data (e.g. cross talk).
+    """
+
+    frac = config.Property(proptype=float, default=1e-4)
+    match_median = config.Property(proptype=bool, default=True)
+
+    def setup(self, data_stack):
+        """Set the stacked data.
+
+        Parameters
+        ----------
+        stack : VisContainer
+        """
+        self.data_stack = data_stack
+
+    def process(self, data):
+        """Blend a small amount of the stack into the incoming data.
+
+        Parameters
+        ----------
+        data : VisContainer
+            The data to be blended into. This is modified in place.
+
+        Returns
+        -------
+        data_blend : VisContainer
+            The modified data. This is the same object as the input, and it has been
+            modified in place.
+        """
+
+        if type(self.data_stack) != type(data):
+            raise TypeError(
+                f"type(data) (={type(data)}) must match"
+                f"type(data_stack) (={type(self.type)}"
+            )
+
+        # Try and get both the stack and the incoming data to have the same
+        # distribution
+        self.data_stack.redistribute(["freq", "time", "ra"])
+        data.redistribute(["freq", "time", "ra"])
+
+        if isinstance(data, containers.SiderealStream):
+            dset_stack = self.data_stack.vis[:]
+            dset = data.vis[:]
+        else:
+            raise TypeError(
+                "Only SiderealStream's are currently supported. "
+                f"Got type(data) = {type(data)}"
+            )
+
+        if dset_stack.shape != dset.shape:
+            raise ValueError(
+                f"Size of data ({dset.shape}) must match "
+                f"data_stack ({dset_stack.shape})"
+            )
+
+        weight_stack = self.data_stack.weight[:]
+        weight = data.weight[:]
+
+        # Find the median offset between the stack and the daily data
+        if self.match_median:
+
+            # Find the parts of the both the stack and the daily data that are both
+            # measured
+            mask = (
+                ((weight[:] > 0) & (weight_stack[:] > 0))
+                .astype(np.float32)
+                .view(np.ndarray)
+            )
+
+            # ... get the median of the stack in this common subset
+            stack_med_real = weighted_median.weighted_median(
+                dset_stack.real.view(np.ndarray).copy(), mask
+            )
+            stack_med_imag = weighted_median.weighted_median(
+                dset_stack.imag.view(np.ndarray).copy(), mask
+            )
+
+            # ... get the median of the data in the common subset
+            data_med_real = weighted_median.weighted_median(
+                dset.real.view(np.ndarray).copy(), mask
+            )
+            data_med_imag = weighted_median.weighted_median(
+                dset.imag.view(np.ndarray).copy(), mask
+            )
+
+            # ... construct an offset to match the medians in the time/RA direction
+            stack_offset = (
+                (data_med_real - stack_med_real)
+                + 1.0j * (data_med_imag - stack_med_imag)
+            )[..., np.newaxis]
+
+        else:
+            stack_offset = 0
+
+        # Perform a weighted average of the data
+        dset *= weight
+        dset += weight_stack * self.frac * (dset_stack + stack_offset)
+        weight += weight_stack * self.frac
+
+        dset *= tools.invert_no_zero(weight)
+
+        return data

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -987,19 +987,25 @@ def tv_channels_flag(x, freq, sigma=5, f=0.5, debug=False):
     tvstart_freq = 398
     tvwidth_freq = 6
 
+    # Calculate the boundaries of each frequency channel
+    df = np.median(np.abs(np.diff(freq)))
+    freq_start = freq - 0.5 * df
+    freq_end = freq + 0.5 * df
+
     for i in range(67):
 
+        # Find all frequencies that lie wholly or partially within the TV channel
         fs = tvstart_freq + i * tvwidth_freq
         fe = fs + tvwidth_freq
-        sel = (freq >= fs) & (freq < fe)
+        sel = (freq_end >= fs) & (freq_start <= fe)
 
         # Calculate the threshold to apply
         N = sel.sum()
         k = int(f * N)
 
-        # This is the Gaussian threshold required for there to be at most a p_false chance of more
-        # than k trials exceeding the threshold. This is the correct expression, and has been double
-        # checked by numerical trials.
+        # This is the Gaussian threshold required for there to be at most a p_false
+        # chance of more than k trials exceeding the threshold. This is the correct
+        # expression, and has been double checked by numerical trials.
         t = p_to_sigma(inverse_binom_cdf_prob(k, N, 1 - p_false))
 
         frac[sel] = (x[sel] > t).mean(axis=0)[np.newaxis, :]


### PR DESCRIPTION
These build ontop of the work that's in #109, so once that's merged we'll need to rebase this PR.

The biggest thing in here is to introduce a new task which requires a stack and then for each input stream it takes a weighted average with a small amount of the stack to fill in holes. This reduces the artifacts in the estimated delay spectrum quite by around an order of magnitude on the data I've used for testing.