### PR TITLE
fix(analysis.flagging.MaskData): Fix m mask.

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -143,7 +143,7 @@ class MaskData(task.SingleTask):
         -------
         mmodes : containers.MModes
         """
-        mmodes.redistribute("m")
+        mmodes.redistribute("freq")
 
         mw = mmodes.weight[:]
 


### PR DESCRIPTION
Previously the code distributed the array over m and then masked
the local m axis instead of globally.

This was causing the periodic artifacts at the declination of bright point sources.