### PR TITLE
Deprecate caput.pipeline.PipelineConfigError

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Run parallel tests
       run: |
-        mpirun -np 4 pytest -x -m mpi test/
+        mpirun -np 4 --oversubscribe pytest -x -m mpi test/
 
     - name: Run caput linter on example configs
       run: |

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -739,9 +739,9 @@ class Truncate(task.SingleTask):
                 or self.fixed_precision is None
                 or self.variance_increase is None
             ):
-                raise pipeline.PipelineConfigError(
+                raise config.CaputConfigError(
                     "Container {} has no preset values. You must define all of 'dataset', "
-                    "'fixed_precision', and 'variance_increase' properties.".format(
+                    "'fixed_precision', and 'variance_increase' properties in the config.".format(
                         container
                     )
                 )
@@ -762,6 +762,14 @@ class Truncate(task.SingleTask):
         -------
         truncated_data : containers.ContainerBase
             Truncated data.
+
+        Raises
+        ------
+        `caput.pipeline.PipelineRuntimeError`
+            If input data has mismatching dataset and weight array shapes.
+        `config.CaputConfigError`
+             If the input data container has no preset values and `fixed_precision` or `variance_increase` are not set
+             in the config.
         """
         # get truncation parameters from config or container defaults
         self._get_params(type(data))

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -250,6 +250,11 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
         attached to output metadata.
     pipeline_config : dict
         Global pipeline configuration. This is attached to output metadata.
+
+    Raises
+    ------
+    `caput.pipeline.PipelineRuntimeError`
+        If this is used as a baseclass to a task overriding `self.process` with variable length or optional arguments.
     """
 
     save = config.Property(default=False, proptype=bool)
@@ -282,7 +287,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
                 "`process` method may not have variable length or optional"
                 " arguments."
             )
-            raise pipeline.PipelineConfigError(msg)
+            raise pipeline.PipelineRuntimeError(msg)
 
         if n_args == 0:
             self._no_input = True

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -2,10 +2,11 @@
 
 import os
 import logging
+from inspect import getfullargspec
 
 import numpy as np
 
-from caput import pipeline, config, memh5, misc
+from caput import pipeline, config, memh5
 
 
 class MPILogFilter(logging.Filter):
@@ -279,7 +280,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
         super(SingleTask, self).__init__()
 
         # Inspect the `process` method to see how many arguments it takes.
-        pro_argspec = misc.getfullargspec(self.process)
+        pro_argspec = getfullargspec(self.process)
         n_args = len(pro_argspec.args) - 1
 
         if pro_argspec.varargs or pro_argspec.varkw or pro_argspec.defaults:


### PR DESCRIPTION
see https://github.com/radiocosmology/caput/pull/156

I don't think these should ever have been config errors, but please correct me if I'm wrong.