### PR TITLE
perf(SingleTask): remove no-effect-__getitem__ call

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -435,7 +435,6 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
                 try:
                     is_nan = np.isnan(arr)
                     is_inf = np.isinf(arr)
-                    arr = n[:]
                 except TypeError:
                     continue
 


### PR DESCRIPTION
I'm not sure if this will speed up `_nan_check_walk`, but I don't see how this line can have an effect anyways.

Percentages are of the total run time of the daily processing pipeline:
- 10% _nan_check_walk (draco.core.task)
  - 7% __getitem__ (memh5)
