### PR TITLE
Misc. tweaks to SourceStack

### DIFF
--- a/draco/analysis/sourcestack.py
+++ b/draco/analysis/sourcestack.py
@@ -79,12 +79,20 @@ class SourceStack(task.SingleTask):
 
         # Get f_mask and qs_indices
         freqdiff = freq[np.newaxis, :] - qso_freq[:, np.newaxis]
-        # Stack axis bin edges to digitize each quasar at.
-        stackbins = self.stack_axis["centre"] + 0.5 * self.stack_axis["width"]
-        stackbins = np.append(
-            stackbins,
-            self.stack_axis["centre"][-1] - 0.5 * self.stack_axis["width"][-1],
-        )
+        # Stack axis bin edges to digitize each quasar at, in either increasing
+        # or decreasing order depending on order of frequencies
+        if self.stack_axis["centre"][0] > self.stack_axis["centre"][-1]:
+            stackbins = self.stack_axis["centre"] + 0.5 * self.stack_axis["width"]
+            stackbins = np.append(
+                stackbins,
+                self.stack_axis["centre"][-1] - 0.5 * self.stack_axis["width"][-1],
+            )
+        else:
+            stackbins = self.stack_axis["centre"] - 0.5 * self.stack_axis["width"]
+            stackbins = np.append(
+                stackbins,
+                self.stack_axis["centre"][-1] + 0.5 * self.stack_axis["width"][-1],
+            )
         # Index of each frequency in stack axis, for each quasar
         qs_indices = np.digitize(freqdiff, stackbins) - 1
         # Indices to be processed in full frequency axis for each quasar


### PR DESCRIPTION
This collects a few minor changes to `draco.analysis.sourcestack.SourceStack`:

- Allowing the use of input `FormedBeam` containers where the frequency axis is either increasing or decreasing. The convention for this is opposite in the `CHIME` telescope class and a generic `driftscan` telescope, so this change allows for stacking with non-`CHIME` telescopes.
- An option to only stack on sources within a specific frequency bin (useful for isolating the stacking signal within a narrow frequency range, as opposed to averaging across the entire band).
- Changing variables and comments to refer to sources instead of quasars/QSOs.