### PR TITLE
fix(ringmapmaker): MPI calls could get out of sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
 
     - name: Install apt dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -75,6 +76,7 @@ jobs:
 
     - name: Install apt dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin
 
     - name: Set up Python 3.9

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -582,7 +582,9 @@ class DeconvolveHybridMBase(task.SingleTask):
         # Dereference datasets
         hv = hybrid_vis_m.vis[:].view(np.ndarray)
         hw = hybrid_vis_m.weight[:].view(np.ndarray)
-        bv = hybrid_beam_m.vis[:].view(np.ndarray)
+
+        # Dereference the beams, and trim to the set of m's present in the input data
+        bv = hybrid_beam_m.vis[:].view(np.ndarray)[: (mmax + 1)]
 
         rmm = rm.map[:]
         rmw = rm.weight[:]

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -547,8 +547,7 @@ class DeconvolveHybridMBase(task.SingleTask):
         m = hybrid_vis_m.index_map["m"]
         mmax = hybrid_vis_m.mmax
 
-        is_odd = np.any(hybrid_vis_m.vis[mmax, 1] != 0.0)
-        nra = 2 * mmax + int(is_odd)
+        nra = 2 * mmax + int(hybrid_vis_m.oddra)
 
         # Create ring map, copying over axes/attrs
         rm = containers.RingMap(
@@ -858,9 +857,7 @@ class DeconvolveAnalyticalBeam(DeconvolveHybridMBase):
 
         # Determine the RA axis from the maximum m-mode in the hybrid visibilities
         mmax = hybrid_vis_m.mmax
-        is_odd = np.any(hybrid_vis_m.vis[mmax, 1] != 0.0)
-        is_odd = hybrid_vis_m.comm.allreduce(is_odd)
-        nra = 2 * mmax + int(is_odd)
+        nra = 2 * mmax + int(hybrid_vis_m.oddra)
 
         dec = np.arcsin(hybrid_vis_m.index_map["el"]) + np.radians(
             self.telescope.latitude

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -488,21 +488,53 @@ class DeconvolveHybridMBase(task.SingleTask):
         else:
             self.telescope = None
 
-    def process(self, hybrid_vis_m: containers.HybridVisMModes) -> containers.RingMap:
-        """Generate a deconvolved ringmap.
+    def process(
+        self,
+        hybrid_vis_m: containers.HybridVisMModes,
+        hybrid_beam_m: containers.HybridVisMModes,
+    ) -> containers.RingMap:
+        """Generate a deconvolved ringmap using an input beam model.
 
         Parameters
         ----------
         hybrid_vis_m : containers.HybridVisMModes
             M-mode transform of hybrid beamformed visibilities.
 
+        hybrid_beam_m : containers.HybridVisMModes
+            M-mode transform of the beam after converting into
+            hybrid beamformed visibilities.
+
         Returns
         -------
-        ringmap : containers.RingMap
-            Deconvolved ring map.
+        ringmap
+            The deconvolved ring map.
         """
+
+        # Validate that the visibilites and beams match
+        if not np.array_equal(hybrid_vis_m.freq, hybrid_beam_m.freq):
+            raise ValueError("Frequencies do not match for beam and visibilities.")
+
+        if not np.array_equal(
+            hybrid_vis_m.index_map["el"], hybrid_beam_m.index_map["el"]
+        ):
+            raise ValueError("Elevations do not match for beam and visibilities.")
+
+        if not np.array_equal(
+            hybrid_vis_m.index_map["ew"], hybrid_beam_m.index_map["ew"]
+        ):
+            raise ValueError("EW baselines do not match for beam and visibilities.")
+
+        if not np.array_equal(
+            hybrid_vis_m.index_map["pol"], hybrid_beam_m.index_map["pol"]
+        ):
+            raise ValueError("Polarisations do not match for beam and visibilities.")
+
+        if hybrid_vis_m.mmax > hybrid_beam_m.mmax:
+            raise ValueError("Beam model must have higher m-max than the visibilities")
+
         # Distribute over frequency
         hybrid_vis_m.redistribute("freq")
+        hybrid_beam_m.redistribute("freq")
 
         # Determine local frequencies
         nfreq = hybrid_vis_m.vis.local_shape[3]
@@ -550,6 +582,7 @@ class DeconvolveHybridMBase(task.SingleTask):
         # Dereference datasets
         hv = hybrid_vis_m.vis[:].view(np.ndarray)
         hw = hybrid_vis_m.weight[:].view(np.ndarray)
+        bv = hybrid_beam_m.vis[:].view(np.ndarray)
 
         rmm = rm.map[:]
         rmw = rm.weight[:]
@@ -562,6 +595,7 @@ class DeconvolveHybridMBase(task.SingleTask):
             find = (slice(None),) * 3 + (lfi,)
 
             hvf = hv[find]
+            bvf = bv[find]
 
             winf = window[lfi]
 
@@ -570,9 +604,6 @@ class DeconvolveHybridMBase(task.SingleTask):
 
             # Get the EW weights using method defined by subclass
             weight = self._get_weight(inv_var) * (inv_var > 0.0)
-
-            # Get the beam m-modes using method defined by subclass
-            bvf = self._get_beam_mmodes(freq, hybrid_vis_m)
 
             # Get the regularisation term, exact prescription is defined by subclass
             epsilon = self._get_regularisation(freq, m)
@@ -718,28 +749,6 @@ class DeconvolveHybridMBase(task.SingleTask):
 
         return window
 
-    def _get_beam_mmodes(self, freq, hybrid_vis_m):
-        """Return the m-mode transform of the beam model at a particular frequency.
-
-        Any subclass must define this method in order to be a functional
-        deconvolving ringmap maker.
-
-        Parameters
-        ----------
-        freq : float
-            The frequency in MHz.
-        hybrid_vis_m : containers.HybridVisMModes
-            The m-mode transform of the hybrid visiblities.
-
-        Returns
-        -------
-        hybrid_beam_m : np.ndarray[nm, nmsign, npol, new, nel]
-            The m-mode transform of the beam model at the requested frequency.
-        """
-        raise NotImplementedError(
-            f"{self.__class__} must define a _get_beam_mmodes method."
-        )
-
     def _get_weight(self, inv_var):
         """Return the weight to be used when averaging over EW baselines.
 
@@ -799,7 +808,31 @@ class DeconvolveAnalyticalBeam(DeconvolveHybridMBase):
 
         self.telescope = io.get_telescope(telescope)
 
-    def _get_beam_mmodes(self, freq, hybrid_vis_m):
+    def process(
+        self,
+        hybrid_vis_m: containers.HybridVisMModes,
+    ) -> containers.RingMap:
+        """Generate a deconvolved ringmap using an analytic beam model.
+
+        Parameters
+        ----------
+        hybrid_vis_m : containers.HybridVisMModes
+            M-mode transform of hybrid beamformed visibilities.
+
+        Returns
+        -------
+        ringmap
+            The deconvolved ring map.
+        """
+
+        # Prepare the external beam m-modes and save to class attribute
+        hybrid_beam_m = self._get_beam_mmodes(hybrid_vis_m)
+
+        return super().process(hybrid_vis_m, hybrid_beam_m)
+
+    def _get_beam_mmodes(
+        self, hybrid_vis_m: containers.HybridVisMModes
+    ) -> containers.HybridVisMModes:
 
         # NOTE: Coefficients taken from Mateus's fits, but adjust to fix the definition
         # of sigma, and be the widths for the "voltage" beam
@@ -821,93 +854,60 @@ class DeconvolveAnalyticalBeam(DeconvolveHybridMBase):
             """Azimuthal beam transfer function."""
             return np.exp(2.0j * np.pi * u * np.sin(phi)) * A(phi, sigma)
 
-        # Deteremine the RA axis from the maximum m-mode in the hybrid visibilities
+        # Determine the RA axis from the maximum m-mode in the hybrid visibilities
         mmax = hybrid_vis_m.mmax
         is_odd = np.any(hybrid_vis_m.vis[mmax, 1] != 0.0)
+        is_odd = hybrid_vis_m.comm.allreduce(is_odd)
         nra = 2 * mmax + int(is_odd)
 
-        ra = np.linspace(0.0, 360.0, nra, endpoint=False)
-        phi_arr = np.radians(ra)[np.newaxis, np.newaxis, np.newaxis, :]
-
-        # Calculate the baseline distance in wavelengths
-        wv = scipy.constants.c * 1e-6 / freq
-        u = hybrid_vis_m.index_map["ew"] / wv
-
-        # Calculate the projected baseline distance
         dec = np.arcsin(hybrid_vis_m.index_map["el"]) + np.radians(
             self.telescope.latitude
         )
-        u_dec = u[:, np.newaxis] * np.cos(dec)[np.newaxis, :]
-        u_arr = u_dec[np.newaxis, :, :, np.newaxis]
-
-        # Construct an array containing the width of the beam for
-        # each polarisation and declination
         pol = hybrid_vis_m.index_map["pol"]
-        sig = np.zeros((pol.size, dec.size), dtype=dec.dtype)
-        for pi, (pa, pb) in enumerate(pol):
 
-            # Get the effective beamwidth for the polarisation combination
-            sig_a = beam_width[pa](freq, dec)
-            sig_b = beam_width[pb](freq, dec)
-            sig[pi] = sig_a * sig_b / (sig_a ** 2 + sig_b ** 2) ** 0.5
+        # Determine RA axis for beam
+        ra = np.linspace(0.0, 360.0, nra, endpoint=False)
+        phi_arr = np.radians(ra)[np.newaxis, np.newaxis, np.newaxis, :]
 
-        sig_arr = sig[:, np.newaxis, :, np.newaxis]
+        hybrid_beam_m = containers.empty_like(hybrid_vis_m)
 
-        # Calculate the effective beam transfer function
-        B_arr = B(phi_arr, u_arr, sig_arr)
+        # Loop over all local frequencies and calculate the beam m-modes
+        for lfi, fi in hybrid_vis_m.vis[:].enumerate(axis=3):
 
-        mB = transform._make_marray(B_arr.conj(), mmax=mmax)
+            freq = hybrid_vis_m.freq[fi]
 
-        return mB
+            # Calculate the baseline distance in wavelengths
+            wv = scipy.constants.c * 1e-6 / freq
+            u = hybrid_vis_m.index_map["ew"] / wv
 
+            # Calculate the projected baseline distance
+            u_dec = u[:, np.newaxis] * np.cos(dec)[np.newaxis, :]
+            u_arr = u_dec[np.newaxis, :, :, np.newaxis]
 
-class DeconvolveExternalBeam(DeconvolveHybridMBase):
-    """Base class for deconvolving an external model of the beam (non-functional)."""
+            # Construct an array containing the width of the beam for
+            # each polarisation and declination
+            sig = np.zeros((pol.size, dec.size), dtype=dec.dtype)
+            for pi, (pa, pb) in enumerate(pol):
 
-    def process(
-        self,
-        hybrid_vis_m: containers.HybridVisMModes,
-        hybrid_beam_m: containers.HybridVisMModes,
-    ) -> containers.RingMap:
-        """Generate a deconvolved ringmap using an external beam model.
+                # Get the effective beamwidth for the polarisation combination
+                sig_a = beam_width[pa](freq, dec)
+                sig_b = beam_width[pb](freq, dec)
+                sig[pi] = sig_a * sig_b / (sig_a ** 2 + sig_b ** 2) ** 0.5
 
-        Parameters
-        ----------
-        hybrid_vis_m : containers.HybridVisMModes
-            M-mode transform of hybrid beamformed visibilities.
+            sig_arr = sig[:, np.newaxis, :, np.newaxis]
 
-        hybrid_beam_m : containers.HybridVisMModes
-            M-mode transform of the beam after converting into
-            hybrid beamformed visibilities.
+            # Calculate the effective beam transfer function
+            B_arr = B(phi_arr, u_arr, sig_arr)
 
-        Returns
-        -------
-        ringmap
-            The deconvolved ring map.
-        """
-        # Prepare the external beam m-modes and save to class attribute
-        hybrid_beam_m.redistribute("freq")
+            hybrid_beam_m.vis[:, :, :, fi] = transform._make_marray(
+                B_arr.conj(), mmax=mmax
+            )
 
-        fstart = hybrid_beam_m.vis.local_offset[3]
-        fstop = fstart + hybrid_beam_m.vis.local_shape[3]
-
-        self.beam_freq = hybrid_beam_m.freq[fstart:fstop]
-        self.beam_mmodes = hybrid_beam_m.vis[:].view(np.ndarray)
-
-        return super(DeconvolveExternalBeam, self).process(hybrid_vis_m)
-
-    def _get_beam_mmodes(self, freq, hybrid_vis_m):
-
-        ifreq = np.argmin(np.abs(freq - self.beam_freq))
-
-        if np.abs(freq - self.beam_freq[ifreq]) > 0.0:
-            raise RuntimeError("Frequency axis of the beam m-modes does not match.")
-
-        return self.beam_mmodes[:, :, :, ifreq]
+        return hybrid_beam_m
 
 
 class TikhonovRingMapMaker(DeconvolveHybridMBase):
-    """Base class for making maps using a Tikhonov regularisation scheme (non-functional).
+    """Class for making maps using a Tikhonov regularisation scheme.
 
     Attributes
     ----------
@@ -959,7 +959,7 @@ class TikhonovRingMapMaker(DeconvolveHybridMBase):
 
 
 class WienerRingMapMaker(DeconvolveHybridMBase):
-    """Base class for map making using a Wiener regularisation scheme (non-functional).
+    """Class for map making using a Wiener regularisation scheme.
 
     Compared to TikhonovRingMapMaker, this task has a frequency and m-mode
     dependent regularisation parameter given by the ratio of the noise spectrum
@@ -1030,16 +1030,13 @@ class TikhonovRingMapMakerAnalytical(DeconvolveAnalyticalBeam, TikhonovRingMapMa
     """Make a ringmap using Tikhonov deconvolution of an analytical beam model."""
 
 
-class TikhonovRingMapMakerExternal(DeconvolveExternalBeam, TikhonovRingMapMaker):
-    """Make a ringmap using Tikhonov deconvolution of an external beam model."""
-
-
 class WienerRingMapMakerAnalytical(DeconvolveAnalyticalBeam, WienerRingMapMaker):
     """Make a ringmap using Wiener deconvolution of an analytical beam model."""
 
 
-class WienerRingMapMakerExternal(DeconvolveExternalBeam, WienerRingMapMaker):
-    """Make a ringmap using Wiener deconvolution of an external beam model."""
+# Aliases to support old names
+TikhonovRingMapMakerExternal = TikhonovRingMapMaker
+WienerRingMapMakerExternal = WienerRingMapMaker
 
 
 class RADependentWeights(task.SingleTask):

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -498,6 +498,8 @@ class MModeTransform(task.SingleTask):
         ma.redistribute("freq")
 
         # Generate the m-mode transform directly into the output container
+        # NOTE: Need to zero fill as not every element gets set within _make_marray
+        ma.vis[:] = 0.0
         _make_marray(sstream.vis[:], ma.vis[:])
 
         # Assign the weights into the container

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -617,6 +617,20 @@ class MModeInverseTransform(task.SingleTask):
         return sstream
 
 
+class SiderealMModeResample(task.group_tasks(MModeTransform, MModeInverseTransform)):
+    """Resample a sidereal stream by FFT.
+
+    This performs a forward and inverse m-mode transform to resample a sidereal stream.
+
+    Attributes
+    ----------
+    nra
+        The number of RA bins for the output stream.
+    """
+
+    nra = config.Property(proptype=int, default=None)
+
+
 def _make_ssarray(mmodes, n=None):
     # Construct an array of sidereal time streams from m-modes
     marray = _unpack_marray(mmodes, n=n)

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -2,6 +2,8 @@
 
 This includes grouping frequencies and products to performing the m-mode transform.
 """
+from typing import Optional
+
 import numpy as np
 from numpy.lib.recfunctions import structured_to_unstructured
 from caput import mpiarray, config
@@ -441,7 +443,7 @@ class MModeTransform(task.SingleTask):
     time samples, or if a manager is supplied `telescope.mmax` is used.
     """
 
-    def setup(self, manager=None):
+    def setup(self, manager: Optional[io.TelescopeConvertible] = None):
         """Set the telescope instance if a manager object is given.
 
         This is used to set the `mmax` used in the transform.
@@ -457,7 +459,7 @@ class MModeTransform(task.SingleTask):
         else:
             self.telescope = None
 
-    def process(self, sstream):
+    def process(self, sstream: containers.SiderealContainer) -> containers.MContainer:
         """Perform the m-mode transform.
 
         Parameters
@@ -578,7 +580,7 @@ class MModeInverseTransform(task.SingleTask):
 
     nra = config.Property(proptype=int, default=None)
 
-    def process(self, mmodes):
+    def process(self, mmodes: containers.MContainer) -> containers.SiderealContainer:
         """Perform the m-mode inverse transform.
 
         Parameters

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -56,6 +56,7 @@ their own custom container types.
 """
 
 import inspect
+from typing import Optional
 
 import numpy as np
 from caput import memh5, tod
@@ -937,11 +938,17 @@ class MContainer(ContainerBase):
     ----------
     mmax : integer, optional
         Largest m to be held.
+    oddra : bool, optional
+        Does this MContainer come from an underlying odd number of RA points. This
+        determines if the largest negative m is filled or not (it is for odd=True, not
+        for odd=False). Default is odd=False.
     """
 
     _axes = ("m", "msign")
 
-    def __init__(self, mmax=None, *args, **kwargs):
+    def __init__(
+        self, mmax: Optional[int] = None, oddra: Optional[bool] = None, *args, **kwargs
+    ):
 
         # Set up axes from passed arguments
         if mmax is not None:
@@ -952,10 +959,21 @@ class MContainer(ContainerBase):
 
         super().__init__(*args, **kwargs)
 
+        # Set oddra, prioritising an explicit keyword argument over anything else
+        if oddra is not None:
+            self.attrs["oddra"] = oddra
+        elif "oddra" not in self.attrs:
+            self.attrs["oddra"] = False
+
     @property
-    def mmax(self):
+    def mmax(self) -> int:
         """The maximum m stored."""
         return int(self.index_map["m"][-1])
+
+    @property
+    def oddra(self) -> bool:
+        """Whether this represents an odd or even number of RA points."""
+        return self.attrs["oddra"]
 
 
 class HealpixContainer(ContainerBase):


### PR DESCRIPTION
This fixes a nasty bug where MPI calls could get out of sync when using
`DeconvolveAnalyticalBeam` in a case where different ranks have
differing numbers of frequencies. To rectify this it refactors the code
such that the beam_mmodes are generate for all frequencies at once which
will prevent the bug from resurfacing in newer implementations.