### PR TITLE
build: raise minimum required numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ caput @ git+https://github.com/radiocosmology/caput.git
 cora @ git+https://github.com/radiocosmology/cora.git
 Cython>0.18
 mpi4py
-numpy>=1.17
+numpy>=1.20.3
 scipy>=0.10
 skyfield


### PR DESCRIPTION
i"There was a change in the C API
(https://numpy.org/doc/stable/release/1.20.0-notes.html#size-of-np-ndarray-and-np-void-changed)
in numpy 1.20.0. This can result in issues with running draco if the build version of
numpy, and the installed version, differed.