### PR TITLE
build: build using the oldest supported version of numpy, for python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'numpy>=1.7']
+requires = ['setuptools', 'wheel', 'Cython', 'oldest-supported-numpy']
 
 [tool.pytest.ini_options]
 minversion = "6"


### PR DESCRIPTION
Binaries compiled with old Numpy versions are ABI compatible with
newer Numpy versions, but not vice-versa.

Discussion on this here: https://numpy.org/devdocs/user/depending_on_numpy.html

To avoid running issues into on cedar, we should build using the oldest
compatible numpy version. We can then run packages using whatever newer
Numpy version we want.

Conversation here: https://github.com/radiocosmology/draco/pull/145

This does fail the following test:

```
 deactivate                                                                                                                                                                                      
 mkdir -p ./venv                                                                                                                                                                                  
 mkdir -p ./code                                                                                                                                                                                  
 virtualenv --system-site-packages --prompt=pipelinetest ./venv                                                                                                                                   
 source venv/bin/activate                                                                                                                                                                         
 pip install --upgrade numpy                                                                                                                                                                      
 pip install --no-build-isolation -vvv --src ./code/ -e git+ssh://git@github.com/radiocosmology/draco@numpy-build#egg=draco &> stdout.log                                                         
 pip uninstall numpy
 ```                                                                                                                                                                      

> ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject

This is because of:
> pip has --no-use-pep517 and --no-build-isolation flags that may ignore pyproject.toml or treat it differently - if users use those flags, they are responsible for installing the correct build dependencies themselves.

`--no-build-isolation` is used by `mkchimeenv.sh`.