### PR TITLE
fix(ContainerBase): correctly call superconstructor

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -142,7 +142,7 @@ class ContainerBase(memh5.BasicCont):
         self.allow_chunked = kwargs.pop("allow_chunked", False)
 
         # Run base initialiser
-        memh5.BasicCont.__init__(self, distributed=dist, comm=comm)
+        super().__init__(distributed=dist, comm=comm)
 
         # Check to see if this call looks like it was called like
         # memh5.MemDiskGroup would have been. If it is, we're probably trying to


### PR DESCRIPTION
For some reason ContainerBase doesn't call its superconstructor via `super()`
but with a direct class reference. Unfortunately in sitations with multiple
inheritance this results in objects not being correctly initialised as the
explicit class reference wasn't actually next in the MRO.

I'm not sure if this is clearly a bug, or if it's actually a deliberate choice
that I don't understand the rationale behind. At the moment I don't see how it
can make any difference, there are very few containers using multiple
inheritance and they don't typically have constructors, so I can't really
envisage a scenario where `super()` would call something different from the
explicit call.

Anyway, this should at least be tested by running through a day of the daily
pipeline with it.
