### PR TITLE
ss/tel-beam-stream

### DIFF
--- a/draco/analysis/beam.py
+++ b/draco/analysis/beam.py
@@ -49,7 +49,7 @@ class CreateBeamStream(task.SingleTask):
         )
 
     def process(self, data, beam):
-        """Convert the beam model into a format that can be applied to the data.
+        """Convert the beam model into a format that can be deconvolved from data.
 
         Parameters
         ----------
@@ -166,7 +166,7 @@ class CreateBeamStreamFromTelescope(CreateBeamStream):
     """Create a HybridVisStream from a telescope instance."""
 
     def process(self, data):
-        """Convert the beam model into a format that can be applied to the data.
+        """Convert a telescope's beam into a format that can be deconvolved from data.
 
         Parameters
         ----------
@@ -233,7 +233,7 @@ class CreateBeamStreamFromTelescope(CreateBeamStream):
         )
 
         local_freq_flag = np.abs(
-            local_freq["center"] - self.telescope.frequencies[local_freq_index]
+            local_freq["centre"] - self.telescope.frequencies[local_freq_index]
         ) <= (0.5 * local_freq["width"])
 
         # Construct a vector that contains the coordinates in the format


### PR DESCRIPTION
Adds a new `CreateBeamStreamFromTelescope` task that evaluates
the beam model in a telescope instance to construct a `GridBeam`,
which is then passed to the `CreateBeamStream` superclass to convert
to `HybridVisStream` for use in the deconvolving ringmap maker.