### PR TITLE
fix(task): if finish task output is None, it should not be processed

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -356,6 +356,11 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
 
         output = self.process_finish()
 
+        # Return immediately if output is None to skip writing phase.
+        if output is None:
+            self.log.info(f"Leaving finish for task {class_name}")
+            return None
+
         output = self._process_output(output)
 
         self.log.info(f"Leaving finish for task {class_name}")
@@ -363,6 +368,11 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
         return output
 
     def _process_output(self, output, input_tag=None):
+
+        if not isinstance(output, memh5.MemDiskGroup):
+            raise pipeline.PipelineRuntimeError(
+                f"Task must output a valid memh5 container; given {type(output)}"
+            )
 
         # Set the tag according to the format
         output.attrs["tag"] = self.tag.format(
@@ -409,6 +419,11 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
     def _nan_process_output(self, output):
         # Process the output to check for NaN's
         # Returns the output or, None if it should be skipped
+
+        if not isinstance(output, memh5.MemDiskGroup):
+            raise pipeline.PipelineRuntimeError(
+                f"Task must output a valid memh5 container; given {type(output)}"
+            )
 
         if self.nan_check:
             nan_found = self._nan_check_walk(output)


### PR DESCRIPTION
- fixes bug where pipeline exceptions, if a task returns a None as a
result to `.finish`

```
59
 5360.3s [MPI  89/128] - INFO     draco.analysis.sidereal.SiderealGrouper: self._timestream_list: [<draco.core.containers.TimeStream object at 0x2b3ac5d29220>, <draco.core.containers.TimeStream object at 0x2b3ac5cc61f0>]                                                                                                                                                                
   5360.3s [MPI   0/128] - INFO     draco.analysis.transform.CollateProducts: Profiling pipeline: 6 cores available.                                                                                                                                                                                                                                                                          
 Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                           
   File "/scratch/anja/code/caput/caput/scripts/runner.py", line 555, in <module>                                                                                                                                                                                                                                                                                                             
     cli()                                                                                                                                                                                                                                                                                                                                                                                    
   File "/project/rpp-chime/chime/chime_env/modules/chime/python/2021.03/lib/python3.8/site-packages/click/core.py", line 829, in __call__                                                                                                                                                                                                                                                    
     return self.main(*args, **kwargs)                                                                                                                                                                                                                                                                                                                                                        
   File "/project/rpp-chime/chime/chime_env/modules/chime/python/2021.03/lib/python3.8/site-packages/click/core.py", line 782, in main                                                                                                                                                                                                                                                        
     rv = self.invoke(ctx)                                                                                                                                                                                                                                                                                                                                                                    
   File "/project/rpp-chime/chime/chime_env/modules/chime/python/2021.03/lib/python3.8/site-packages/click/core.py", line 1259, in invoke                                                                                                                                                                                                                                                     
     return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                                                                                                                                                                                                  
   File "/project/rpp-chime/chime/chime_env/modules/chime/python/2021.03/lib/python3.8/site-packages/click/core.py", line 1066, in invoke                                                                                                                                                                                                                                                     
     return ctx.invoke(self.callback, **ctx.params)                                                                                                                                                                                                                                                                                                                                           
   File "/project/rpp-chime/chime/chime_env/modules/chime/python/2021.03/lib/python3.8/site-packages/click/core.py", line 610, in invoke                                                                                                                                                                                                                                                      
     return callback(*args, **kwargs)                                                                                                                                                                                                                                                                                                                                                         
   File "/scratch/anja/code/caput/caput/scripts/runner.py", line 161, in run                                                                                                                                                                                                                                                                                                                  
     P.run()                                                                                                                                                                                                                                                                                                                                                                                  
   File "/scratch/anja/code/caput/caput/pipeline.py", line 633, in run                                                                                                                                                                                                                                                                                                                        
     out = task._pipeline_next()                                                                                                                                                                                                                                                                                                                                                              
   File "/scratch/anja/code/caput/caput/pipeline.py", line 1094, in _pipeline_next                                                                                                                                                                                                                                                                                                            
     out = self.finish()                                                                                                                                                                                                                                                                                                                                                                      
   File "/scratch/anja/code/draco/draco/core/task.py", line 359, in finish                                                                                                                                                                                                                                                                                                                    
     output = self._process_output(output)                                                                                                                                                                                                                                                                                                                                                    
   File "/scratch/anja/code/draco/draco/core/task.py", line 369, in _process_output                                                                                                                                                                                                                                                                                                           
     count=self._count, tag=output.attrs.get("tag", input_tag or self._count)                                                                                                                                                                                                                                                                                                                 
 AttributeError: 'NoneType' object has no attribute 'attrs'    
 ```

I saw at least a few places where the pipeline would exception, if output was a `None`. In another part of `task.py`, the `output` check is done before it is passed to `_process_output`. I repeated that for `finish()`, but it also did not make sense to me for `_process_output` to generally exception on a `None`. So I added the check there too. 

A `None` should be returned in these cases, because then `_check_task_output` does the right thing:

```
     def _check_task_output(out, task):                                                                                                                                                                            
    ....                                                                                                                                                                                            
         if out is None:  # This iteration supplied no output                                                                                                                                                      
             return None
 ```