### PR TITLE
feat(sourcestack): tools to generate many mock stacks

### DIFF
--- a/draco/analysis/sourcestack.py
+++ b/draco/analysis/sourcestack.py
@@ -239,7 +239,7 @@ class RandomSubset(task.SingleTask, RandomTask):
                 self.distributed_axis = max(axis_size, key=axis_size.get)
 
                 self.log.info(
-                    f"Distributing over the {self.distributed_axis} "
+                    f"Distributing over the {self.distributed_axis} axis "
                     "to take random subsets of objects."
                 )
                 catalog.redistribute(self.distributed_axis)
@@ -320,7 +320,7 @@ class RandomSubset(task.SingleTask, RandomTask):
         return new_catalog
 
 
-class CollectFrequencyStacks(task.SingleTask):
+class GroupSourceStacks(task.SingleTask):
     """Accumulate many frequency stacks into a single container.
 
     Attributes

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -29,6 +29,8 @@ Containers
 - :py:class:`SVDSpectrum`
 - :py:class:`FrequencyStack`
 - :py:class:`FrequencyStackByPol`
+- :py:class:`MockFrequencyStack`
+- :py:class:`MockFrequencyStackByPol`
 - :py:class:`SourceCatalog`
 - :py:class:`SpectroscopicCatalog`
 - :py:class:`FormedBeam`
@@ -2231,6 +2233,54 @@ class FrequencyStackByPol(FrequencyStack):
     @property
     def pol(self):
         return self.index_map["pol"]
+
+
+class MockFrequencyStack(FrequencyStack):
+    """Container for holding a frequency stack for multiple mock catalogs.
+
+    Adds a `mock` axis as the first dimension of each dataset.
+    """
+
+    _axes = ("mock",)
+
+    _dataset_spec = {
+        "stack": {
+            "axes": ["mock", "freq"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": False,
+        },
+        "weight": {
+            "axes": ["mock", "freq"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": False,
+        },
+    }
+
+
+class MockFrequencyStackByPol(FrequencyStackByPol):
+    """Container for holding a frequency stack split by pol for multiple mock catalogs.
+
+    Adds a `mock` axis as the first dimension of each dataset.
+    """
+
+    _axes = ("mock",)
+
+    _dataset_spec = {
+        "stack": {
+            "axes": ["mock", "pol", "freq"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": False,
+        },
+        "weight": {
+            "axes": ["mock", "pol", "freq"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": False,
+        },
+    }
 
 
 class Stack3D(FreqContainer):


### PR DESCRIPTION
* Creates MockFrequencyStack and MockFrequencyStackByPol,
which adds a mock axis to the stack and weight dataset,
so stacks on many mock catalogs can be stored in a single container.

* Updates RandomSubset to handle both SpectroscopicCatalog
and FormedBeam containers.

* Create GroupSourceStacks task, which accumulates FrequencyStacks
into the corresponding MockFrequencyStack container.