### PR TITLE
doc(io.LoadFileFromParams): Remove note about index selection.

### DIFF
--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -387,8 +387,6 @@ class BaseLoadFiles(task.SingleTask):
     name>_index` keys are given the former will take precedence, but you should
     clearly avoid doing this.
 
-    Additionally index based selections currently don't work for distributed reads.
-
     Here's an example in the YAML format that the pipeline uses:
 
     .. code-block:: yaml


### PR DESCRIPTION
Distributed reads with index selection should now work.