### PR TITLE
fix(SingleTask): pull tag from input_tags, when not explicitly configured

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -411,7 +411,9 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
         delays = np.fft.fftshift(np.fft.fftfreq(ndelay, d=self.freq_spacing))  # in us
 
         # Initialise the spectrum container
-        delay_spec = containers.DelaySpectrum(baseline=baselines, delay=delays)
+        delay_spec = containers.DelaySpectrum(
+            baseline=baselines, delay=delays, attrs_from=ss
+        )
         delay_spec.redistribute("baseline")
         delay_spec.spectrum[:] = 0.0
 
@@ -609,7 +611,9 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
         # Use the "baselines" axis to generically represent all the other axes
 
         # Initialise the spectrum container
-        delay_spec = containers.DelaySpectrum(baseline=nbase, delay=delays)
+        delay_spec = containers.DelaySpectrum(
+            baseline=nbase, delay=delays, attrs_from=ss
+        )
         delay_spec.redistribute("baseline")
         delay_spec.spectrum[:] = 0.0
         bl_axes = [da for da in data_axes if da not in [self.average_axis, "freq"]]

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -466,8 +466,15 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
     def _interpolation_dict(self, output):
         # Get the set of variables the can be interpolated into the various strings
         idict = dict(output.attrs)
+        if "tag" in output.attrs:
+            tag = output.attrs["tag"]
+        elif "input_tags" in output.attrs and len(output.attrs["input_tags"]):
+            tag = output.attrs["input_tags"][0]
+        else:
+            tag = self._count
+
         idict.update(
-            tag=(output.attrs["tag"] if "tag" in output.attrs else self._count),
+            tag=tag,
             count=self._count,
             task=self.__class__.__name__,
             key=(


### PR DESCRIPTION
Fixes bug introduced in bbbc6b4505e7065ca1c50f0784e11a8c7775dbe6. Input
tags stopped being referenced when setting the tag on the output.

Needed to tag delayspectrum files properly in the daily pipeline.

This reverts to previous behaviour. If this was behaviour that was intentionally removed, we will need to ensure that the tag is properly set on `delayspectrum` output containers.