### PR TITLE
fix(task.SingleTask): ensure input tags are strings.

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -332,7 +332,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
             (
                 str(icont.attrs.get("tag"))
                 if isinstance(icont, memh5.MemDiskGroup)
-                else None
+                else ""
             )
             for icont in input
         ]


### PR DESCRIPTION
If an input to `process` doesn't have a tag, `None` is added to this list. When the container is written to disk, the attributes parser in `memh5.copyattrs` doesn't catch a list of mixed types (`str` and `None` in this case) and output to HDF5 fails.

Maybe we'd like `memh5` to parse these mixed lists as well (possibly by checking for `dtype("O")`) but I think it also makes sense that the input tags be strings (this PR).