### PR TITLE
style:

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -994,7 +994,7 @@ class HealpixContainer(ContainerBase):
 
         # Set up axes from passed arguments
         if nside is not None:
-            kwargs["pixel"] = 12 * nside**2
+            kwargs["pixel"] = 12 * nside ** 2
 
         super().__init__(*args, **kwargs)
 
@@ -2076,6 +2076,26 @@ class DelaySpectrum(ContainerBase):
     _dataset_spec = {
         "spectrum": {
             "axes": ["baseline", "delay"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        }
+    }
+
+    @property
+    def spectrum(self):
+        return self.datasets["spectrum"]
+
+
+class delayspec(ContainerBase):
+    """Container for a delay spectrum."""
+
+    _axes = ("baseline", "ra", "delay")
+
+    _dataset_spec = {
+        "spectrum": {
+            "axes": ["baseline", "ra", "delay"],
             "dtype": np.float64,
             "initialise": True,
             "distributed": True,


### PR DESCRIPTION
This will generate the delay spectrum at each RA and DEC using Wiener filter method. 
The DelaySpectrumWienerBase class in draco.analysis.delay.py will take ringmap and corresponding delay power spectrum as input and estimate the delay spectrum for all RA and DEC.