### PR TITLE
fix(containers): fixes bug setting compression parameters for copy

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -486,9 +486,9 @@ class ContainerBase(memh5.BasicCont):
                 dset[:] = data[:]
                 memh5.copyattrs(data.attrs, dset.attrs)
                 # TODO Is there a case where these properties don't exist?
-                data.chunks = dset.chunks
-                data.compression = dset.compression
-                data.compression_opts = dset.compression_opts
+                dset.chunks = data.chunks
+                dset.compression = data.compression
+                dset.compression_opts = data.compression_opts
 
         return new_cont
 


### PR DESCRIPTION
It looks like the copy was accidentally swapped with the original container when setting the compression parameters.