### PR TITLE
Ljg/threashold vis weight

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -5,6 +5,7 @@ data; and pre-map making flagging on m-modes.
 """
 
 from typing import Union
+import warnings
 import numpy as np
 import scipy.signal
 from scipy.ndimage import median_filter
@@ -659,8 +660,11 @@ class ThresholdVisWeight(task.SingleTask):
             mean_baseline > self.absolute_threshold, mean_baseline, np.nan
         )
         # Average across the time (ra) axis to get per-frequency thresholds,
-        # ignoring any nans
-        threshold = np.nanmean(threshold, axis=2, keepdims=True)
+        # ignoring any nans. np.nanmean will give a warning if an entire band is
+        # nan, which we expect to happen in some cases.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", message="Mean of empty slice")
+            threshold = np.nanmean(threshold, axis=2, keepdims=True)
         # Create a 2D baseline-independent mask.
         mask = ~(
             mean_baseline.local_array

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -672,12 +672,11 @@ class ThresholdVisWeight(task.SingleTask):
         )[:, 0, :]
         # Collect all parts of the mask. Method .allgather() returns a np.ndarray
         mask = mpiarray.MPIArray.wrap(mask, axis=0).allgather()
-        if self.comm.rank == 0:
-            # Log the percent of data masked
-            drop_frac = np.sum(mask) / np.prod(mask.shape)
-            self.log.info(
-                "%0.5f%% of data is below the weight threshold" % (100.0 * (drop_frac))
-            )
+        # Log the percent of data masked
+        drop_frac = np.sum(mask) / np.prod(mask.shape)
+        self.log.info(
+            "%0.5f%% of data is below the weight threshold" % (100.0 * (drop_frac))
+        )
 
         out.mask[:] = mask
 

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -111,7 +111,7 @@ def _list_or_glob(files: Union[str, List[str]]) -> List[str]:
     return files
 
 
-def _list_of_filegroups(groups: Union[List[Dict] or Dict]) -> List[Dict]:
+def _list_of_filegroups(groups: Union[List[Dict], Dict]) -> List[Dict]:
     """Process a file group/groups
 
     Parameters


### PR DESCRIPTION
Updates `ThresholdVisWeight` to be baseline-independent, returning a `RFIMask` container. 

The mask is created by taking a median over all baselines, clipping any values below an absolute threshold, then taking a median in time/ra to get a single threshold for each frequency. This threshold is evaluated relative to the median of all baselines to get a 2D mask in frequency+ra/time - i.e., the same mask would be applied to all baselines. 

I'm not fully familiar with how the re-gridding is done but I'd imagine that masking this way could let outliers slip through, since the mask is relative to the median baseline. Alternatively, we could mask all baselines individually and then stack those masks so that the only ra/frequency points allowed through are those that aren't above the threshold in any baseline, but that could be overly aggressive. 