### PR TITLE
Update CollateProducts to remove redistribute calls

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2673,6 +2673,7 @@ def copy_datasets_filter(
     axis: str,
     selection: Union[np.ndarray, list, slice],
     exclude_axes: List[str] = None,
+    allow_distributed: bool = False,
 ):
     """Copy datasets while filtering a given axis.
 
@@ -2717,7 +2718,7 @@ def copy_datasets_filter(
 
         if isinstance(item, memh5.MemDatasetDistributed):
 
-            if item.distributed_axis == axis_ind:
+            if (item.distributed_axis == axis_ind) and not allow_distributed:
                 raise RuntimeError(
                     f"Cannot redistristribute dataset={item.name} along "
                     f"axis={axis_ind} as it is distributed."


### PR DESCRIPTION
CollateProducts is a major bottleneck due almost entirely to multiple `redistibute` calls. Removing the `redistribute` calls reduces cumulative time from ~2500 seconds to ~75 seconds. It may not be feasible to do this robustly while distributed across frequency.