### PR TITLE
Fix Gibbs sampler bug and add initial_amplitude parameter, and fix misc. MPIArray warnings

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -439,7 +439,7 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
 
         initial_S = np.ones_like(delays) * 1e1
 
-        # Get the random Generator that we will use
+        # Initialize the random number generator we'll use
         rng = self.rng
 
         # Iterate over all baselines and use the Gibbs sampler to estimate the spectrum
@@ -667,6 +667,9 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
 
         initial_S = np.ones_like(delays) * 1e1
 
+        # Initialize the random number generator we'll use
+        rng = self.rng
+
         # Iterate over all baselines and use the Gibbs sampler to estimate the spectrum
         for lbi, bi in delay_spec.spectrum[:].enumerate(axis=0):
 
@@ -706,7 +709,7 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
                 window=self.window if self.apply_window else None,
                 fsel=non_zero_channel,
                 niter=self.nsamp,
-                rng=self.rng,
+                rng=rng,
                 complex_timedomain=self.complex_timedomain,
             )
 

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -624,7 +624,7 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
         # Create a view of the dataset with the relevant axes at the back,
         # and all other axes compressed
         data_view = np.moveaxis(
-            ss.datasets[self.dataset][:].view(np.ndarray),
+            ss.datasets[self.dataset][:].local_array,
             [average_axis_pos, freq_axis_pos],
             [-2, -1],
         )
@@ -673,8 +673,8 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
             self.log.debug(f"Delay transforming baseline {bi}/{nbase}")
 
             # Get the local selections
-            data = data_view[lbi].view(np.ndarray)
-            weight = weight_view[lbi].view(np.ndarray)
+            data = data_view.local_array[lbi]
+            weight = weight_view.local_array[lbi]
 
             # Mask out data with completely zero'd weights and generate time
             # averaged weights

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -362,6 +362,9 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
         Whether to assume the original time samples that were channelized into a
         frequency spectrum were purely real (False) or complex (True). If True,
         `freq_zero`, `nfreq`, and `skip_nyquist` are ignored. Default: False.
+    initial_amplitude : float, optional
+        The Gibbs sampler will be initialized with a flat power spectrum with
+        this amplitude. Default: 10.
     """
 
     nsamp = config.Property(proptype=int, default=20)
@@ -374,6 +377,7 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
         ["nuttall", "blackman_nuttall", "blackman_harris"], default="nuttall"
     )
     complex_timedomain = config.Property(proptype=bool, default=False)
+    initial_amplitude = config.Property(proptype=float, default=10.0)
 
     def setup(self, telescope):
         """Set the telescope needed to generate Stokes I.
@@ -437,7 +441,7 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
         delay_spec.redistribute("baseline")
         delay_spec.spectrum[:] = 0.0
 
-        initial_S = np.ones_like(delays) * 1e1
+        initial_S = np.ones_like(delays) * self.initial_amplitude
 
         # Initialize the random number generator we'll use
         rng = self.rng
@@ -535,6 +539,9 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
         Whether to assume the original time samples that were channelized into a
         frequency spectrum were purely real (False) or complex (True). If True,
         `freq_zero`, `nfreq`, and `skip_nyquist` are ignored. Default: False.
+    initial_amplitude : float, optional
+        The Gibbs sampler will be initialized with a flat power spectrum with
+        this amplitude. Default: 10.
     """
 
     nsamp = config.Property(proptype=int, default=20)
@@ -549,6 +556,7 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
     dataset = config.Property(proptype=str, default="vis")
     average_axis = config.Property(proptype=str)
     complex_timedomain = config.Property(proptype=bool, default=False)
+    initial_amplitude = config.Property(proptype=float, default=10.0)
 
     def setup(self, telescope: io.TelescopeConvertible):
         """Set the telescope needed to generate Stokes I.
@@ -665,7 +673,7 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
             delay_spec.create_index_map(ax, ss.index_map[ax])
         delay_spec.attrs["baseline_axes"] = bl_axes
 
-        initial_S = np.ones_like(delays) * 1e1
+        initial_S = np.ones_like(delays) * self.initial_amplitude
 
         # Initialize the random number generator we'll use
         rng = self.rng

--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -45,14 +45,9 @@ class SVDSpectrumEstimator(task.SingleTask):
         for mi, m in vis.enumerate(axis=0):
             self.log.debug("Calculating SVD spectrum of m=%i", m)
 
-            vis_m = (
-                vis[mi].view(np.ndarray).transpose((1, 0, 2)).reshape(vis.shape[2], -1)
-            )
+            vis_m = vis.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             weight_m = (
-                weight[mi]
-                .view(np.ndarray)
-                .transpose((1, 0, 2))
-                .reshape(vis.shape[2], -1)
+                weight.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             )
             mask_m = weight_m == 0.0
 
@@ -109,14 +104,9 @@ class SVDFilter(task.SingleTask):
         # Do a quick first pass calculation of all the singular values to get the max on this rank.
         for mi, m in vis.enumerate(axis=0):
 
-            vis_m = (
-                vis[mi].view(np.ndarray).transpose((1, 0, 2)).reshape(vis.shape[2], -1)
-            )
+            vis_m = vis.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             weight_m = (
-                weight[mi]
-                .view(np.ndarray)
-                .transpose((1, 0, 2))
-                .reshape(vis.shape[2], -1)
+                weight.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             )
             mask_m = weight_m == 0.0
 
@@ -135,14 +125,9 @@ class SVDFilter(task.SingleTask):
         # Loop over all m's and remove modes below the combined cut
         for mi, m in vis.enumerate(axis=0):
 
-            vis_m = (
-                vis[mi].view(np.ndarray).transpose((1, 0, 2)).reshape(vis.shape[2], -1)
-            )
+            vis_m = vis.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             weight_m = (
-                weight[mi]
-                .view(np.ndarray)
-                .transpose((1, 0, 2))
-                .reshape(vis.shape[2], -1)
+                weight.local_array[mi].transpose((1, 0, 2)).reshape(vis.shape[2], -1)
             )
             mask_m = weight_m == 0.0
 

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -521,7 +521,7 @@ class MModeTransform(task.SingleTask):
         # Generate the m-mode transform directly into the output container
         # NOTE: Need to zero fill as not every element gets set within _make_marray
         ma.vis[:] = 0.0
-        _make_marray(sstream.vis[:], ma.vis[:])
+        _make_marray(sstream.vis[:].local_array, ma.vis[:].local_array)
 
         # Assign the weights into the container
         ma.weight[:] = weight_sum[np.newaxis, np.newaxis, :, :]


### PR DESCRIPTION
This PR has turned into a Frankenstein of various edits, but they are all relatively minor:

- Fix a few MPIArray warnings I've found in various tasks.

- Fix the following bug in `DelaySpectrumEstimatorBase`: if the input container has a large number of "baselines" with zero data or weights, such that there is an MPI rank that only contains these baselines, the routine that initializes the random number generator will never be called on this rank, because `self.rng` is only called in the argument of `delay_spectrum_gibbs()` in the main loop: https://github.com/radiocosmology/draco/blob/16035533fda1d3af6393f8550ea4424af6808c49/draco/analysis/delay.py#L671-L716, and this will always be skipped. The solution is to explicitly initialize the RNG on all ranks before entering the loop, by calling `rng = self.rng`.

- Allow the user to specify the amplitude of the initial power spectrum guess in `DelaySpectrumEstimator` and `DelaySpectrumEstimatorBase`.