### PR TITLE
Misc. improvements to delay power spectrum estimator

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -1055,8 +1055,8 @@ def delay_spectrum_gibbs(
     # frequency spectrum (taking into account that the zero and Nyquist frequencies are
     # strictly real if the delay spectrum is assumed to be real)
     Ni_r = np.zeros(2 * Ni.shape[0])
-    Ni_r[0::2] = np.where(is_real_freq, Ni, Ni / 2**0.5)
-    Ni_r[1::2] = np.where(is_real_freq, 0.0, Ni / 2**0.5)
+    Ni_r[0::2] = np.where(is_real_freq, Ni, Ni * 2)
+    Ni_r[1::2] = np.where(is_real_freq, 0.0, Ni * 2)
 
     # Create the transpose of the Fourier matrix weighted by the noise
     # (this is used multiple times)

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -10,7 +10,7 @@ from caput import mpiarray, config
 from cora.util import units
 
 from ..core import containers, task, io
-from ..util import random
+from ..util import random, tools
 
 
 class DelayFilter(task.SingleTask):
@@ -356,7 +356,7 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
         default to align with the output of CASPER PFBs.
     apply_window : bool, optional
         Whether to apply apodisation to frequency axis. Default: True.
-    window : one of {'nuttall', 'blackman_nuttall', 'blackman_harris'}, optional
+    window : window available in :func:`draco.util.tools.window_generalised()`, optional
         Apodisation to perform on frequency axis. Default: 'nuttall'.
     complex_timedomain : bool, optional
         Whether to assume the original time samples that were channelized into a
@@ -374,7 +374,17 @@ class DelaySpectrumEstimator(task.SingleTask, random.RandomTask):
     skip_nyquist = config.Property(proptype=bool, default=True)
     apply_window = config.Property(proptype=bool, default=True)
     window = config.enum(
-        ["nuttall", "blackman_nuttall", "blackman_harris"], default="nuttall"
+        [
+            "uniform",
+            "hann",
+            "hanning",
+            "hamming",
+            "blackman",
+            "nuttall",
+            "blackman_nuttall",
+            "blackman_harris",
+        ],
+        default="nuttall",
     )
     complex_timedomain = config.Property(proptype=bool, default=False)
     initial_amplitude = config.Property(proptype=float, default=10.0)
@@ -533,7 +543,7 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
         Name of the axis to take the average over.
     apply_window : bool, optional
         Whether to apply apodisation to frequency axis. Default: True.
-    window : one of {'nuttall', 'blackman_nuttall', 'blackman_harris', optional
+    window : window available in :func:`draco.util.tools.window_generalised()`, optional
         Apodisation to perform on frequency axis. Default: 'nuttall'.
     complex_timedomain : bool, optional
         Whether to assume the original time samples that were channelized into a
@@ -551,7 +561,17 @@ class DelaySpectrumEstimatorBase(task.SingleTask, random.RandomTask):
     skip_nyquist = config.Property(proptype=bool, default=True)
     apply_window = config.Property(proptype=bool, default=True)
     window = config.enum(
-        ["nuttall", "blackman_nuttall", "blackman_harris"], default="nuttall"
+        [
+            "uniform",
+            "hann",
+            "hanning",
+            "hamming",
+            "blackman",
+            "nuttall",
+            "blackman_nuttall",
+            "blackman_harris",
+        ],
+        default="nuttall",
     )
     dataset = config.Property(proptype=str, default="vis")
     average_axis = config.Property(proptype=str)
@@ -795,37 +815,6 @@ def stokes_I(sstream, tel):
     return vis_I, vis_weight, ubase
 
 
-def window_generalised(x, window="nuttall"):
-    """A generalised high-order window at arbitrary locations.
-
-    Parameters
-    ----------
-    x : np.ndarray[n]
-        Location to evaluate at. Must be in the range 0 to 1.
-    window : one of {'nuttall', 'blackman_nuttall', 'blackman_harris'}
-        Type of window function to return.
-
-    Returns
-    -------
-    w : np.ndarray[n]
-        Window function.
-    """
-
-    a_table = {
-        "nuttall": np.array([0.355768, -0.487396, 0.144232, -0.012604]),
-        "blackman_nuttall": np.array([0.3635819, -0.4891775, 0.1365995, -0.0106411]),
-        "blackman_harris": np.array([0.35875, -0.48829, 0.14128, -0.01168]),
-    }
-
-    a = a_table[window]
-
-    t = 2 * np.pi * np.arange(4)[:, np.newaxis] * x[np.newaxis, :]
-
-    w = (a[:, np.newaxis] * np.cos(t)).sum(axis=0)
-
-    return w
-
-
 def fourier_matrix_r2c(N, fsel=None):
     """Generate a Fourier matrix to represent a real to complex FFT.
 
@@ -1050,7 +1039,7 @@ def delay_spectrum_gibbs(
 
         # Construct the window function
         x = fsel * 1.0 / total_freq
-        w = window_generalised(x, window=window)
+        w = tools.window_generalised(x, window=window)
         w = np.repeat(w, 2)
 
         # Apply to the projection matrix and the data
@@ -1208,7 +1197,7 @@ def null_delay_filter(freq, max_delay, mask, num_delay=200, tol=1e-8, window=Tru
 
     # Construct the window function
     x = (freq - freq.min()) / freq.ptp()
-    w = window_generalised(x, window="nuttall")
+    w = tools.window_generalised(x, window="nuttall")
 
     delay = np.linspace(-max_delay, max_delay, num_delay)
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2300,9 +2300,17 @@ class DelaySpectrum(ContainerBase):
         }
     }
 
+    def __init__(self, weight_boost=1.0, *args, **kwargs):
+        super(DelaySpectrum, self).__init__(*args, **kwargs)
+        self.attrs["weight_boost"] = weight_boost
+
     @property
     def spectrum(self):
         return self.datasets["spectrum"]
+
+    @property
+    def weight_boost(self):
+        return self.attrs["weight_boost"]
 
 
 class Powerspectrum2D(ContainerBase):


### PR DESCRIPTION
- Updates `delay.py` to use window functions available in `draco.util.tools`
- Fixes typo in real-imaginary split of inverse noise covariance (see commit message for details)
- Adds parameter to `DelaySpectrumEstimator` and `DelaySpectrumEstimatorBase` that allows the user to increase the weights by a given factor before feeding them to the Gibbs sampler, effectively telling the sampler to assume that the noise power is smaller by that factor

I'll take this out of draft status after I've done a final sanity check that everything works