### PR TITLE
Refactor delay-space measurement code and add features

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -526,7 +526,6 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
         out_cont : `contaiers.DelayTransform` or `containers.DelaySpectrum`
             Output delay spectrum or delay power spectrum.
         """
-
         nbase = out_cont.spectrum.global_shape[0]
 
         # Set initial conditions for delay power spectrum
@@ -629,7 +628,6 @@ class DelayGeneralContainerBase(DelayTransformBase):
         out_cont : `containers.DelayTransform` or `containers.DelaySpectrum`
             Container for output delay spectrum or power spectrum.
         """
-
         if self.dataset not in ss.datasets:
             raise ValueError(
                 f"Specified dataset to delay transform ({self.dataset}) not in "
@@ -718,6 +716,7 @@ class DelayPowerSpectrumStokesIEstimator(DelayGibbsSamplerBase):
         Parameters
         ----------
         telescope : TransitTelescope
+            Telescope object we'll use for baseline and polarization information.
         """
         self.telescope = io.get_telescope(telescope)
 
@@ -738,7 +737,6 @@ class DelayPowerSpectrumStokesIEstimator(DelayGibbsSamplerBase):
         out_cont : `containers.DelayTransform` or `containers.DelaySpectrum`
             Container for output delay spectrum or power spectrum.
         """
-
         tel = self.telescope
 
         # Construct the Stokes I vis, and transpose from [baseline, freq, ra] to
@@ -792,6 +790,7 @@ class DelaySpectrumWienerEstimator(DelayGeneralContainerBase):
         Parameters
         ----------
         dps : `containers.DelaySpectrum`
+            Delay power spectrum for signal part of Wiener filter.
         """
         self.dps = dps
 
@@ -812,7 +811,6 @@ class DelaySpectrumWienerEstimator(DelayGeneralContainerBase):
         out_cont : `containers.DelaySpectrum`
             Output delay spectrum.
         """
-
         nbase = out_cont.spectrum.global_shape[0]
 
         # Read the delay power spectrum to use as the signal covariance
@@ -1094,7 +1092,6 @@ def _compute_delay_spectrum_inputs(data, N, Ni, fsel, window, complex_timedomain
     These quantities are needed by both :func:`delay_power_spectrum_gibbs` and
     :func:`delay_spectrum_wiener_filter`, so we compute them in this separate routine.
     """
-
     total_freq = N if complex_timedomain else N // 2 + 1
 
     if fsel is None:

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -424,6 +424,10 @@ class DelayTransformBase(task.SingleTask):
         # doing. Also get empty container for output (DelayTransform or DelaySpectrum)
         data_view, weight_view, out_cont = self._process_data(ss)
 
+        # Save the frequency axis of the input data as an attribute in the output
+        # container
+        out_cont.attrs["freq"] = ss.freq
+
         # Evaluate frequency->delay transform. (self._evaluate take the empty output
         # container, fills it, and returns it)
         out_cont = self._evaluate(data_view, weight_view, out_cont)

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -1359,15 +1359,16 @@ def wiener_filter(
         S = 0.5 * np.repeat(delay_PS, 2)
         Si = 1.0 / S
     else:
-        Si = 1 / delay_PS
+        Si = 1.0 / delay_PS
 
     Ci = np.diag(Si) + FTNiF
 
-    # Solve the linear equation for the Wiener-filtered spectrum
-    y_spec = la.solve(Ci, y, sym_pos=True)
+    # Solve the linear equation for the Wiener-filtered spectrum, and transpose to
+    # [average_axis, delay]
+    y_spec = la.solve(Ci, y, sym_pos=True).T
 
     if complex_timedomain:
-        y_spec = _alternating_real_to_complex(y_spec.T)
+        y_spec = _alternating_real_to_complex(y_spec)
 
     return y_spec
 

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -564,7 +564,7 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
             # Increase the weights by a specified amount
             weight *= self.weight_boost
 
-            spec = delay_spectrum_gibbs(
+            spec = delay_power_spectrum_gibbs(
                 data,
                 self.ndelay,
                 weight,
@@ -1087,7 +1087,7 @@ def _alternating_real_to_complex(array):
 def _compute_delay_spectrum_inputs(data, N, Ni, fsel, window, complex_timedomain):
     """Compute quantities needed for Gibbs sampling and/or Wiener filtering.
 
-    These quantities are needed by both :func:`delay_spectrum_gibbs` and
+    These quantities are needed by both :func:`delay_power_spectrum_gibbs` and
     :func:`delay_spectrum_wiener_filter`, so we compute them in this separate routine.
     """
 
@@ -1141,7 +1141,7 @@ def _compute_delay_spectrum_inputs(data, N, Ni, fsel, window, complex_timedomain
     return data, FTNih, FTNiF
 
 
-def delay_spectrum_gibbs(
+def delay_power_spectrum_gibbs(
     data,
     N,
     Ni,
@@ -1303,6 +1303,10 @@ def delay_spectrum_gibbs(
         spec.append(S_samp)
 
     return spec
+
+
+# Alias delay_spectrum_gibbs to delay_power_spectrum_gibbs, for backwards compatibility
+delay_spectrum_gibbs = delay_power_spectrum_gibbs
 
 
 def delay_spectrum_wiener_filter(

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -1103,8 +1103,8 @@ def _compute_delay_spectrum_inputs(data, N, Ni, fsel, window, complex_timedomain
     # frequency spectrum (taking into account that the zero and Nyquist frequencies are
     # strictly real if the delay spectrum is assumed to be real)
     Ni_r = np.zeros(2 * Ni.shape[0])
-    Ni_r[0::2] = np.where(is_real_freq, Ni, Ni / 2**0.5)
-    Ni_r[1::2] = np.where(is_real_freq, 0.0, Ni / 2**0.5)
+    Ni_r[0::2] = np.where(is_real_freq, Ni, Ni * 2)
+    Ni_r[1::2] = np.where(is_real_freq, 0.0, Ni * 2)
 
     # Create the transpose of the Fourier matrix weighted by the noise
     # (this is used multiple times)

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -855,7 +855,7 @@ class DelaySpectrumWienerEstimator(DelayGeneralContainerBase):
             # to the Wiener filtering routine.The delay power spectrum has been
             # fftshifted in the DelaySpectrumEstimatorBase task, so need to do another
             # fftshift.
-            y_spec = wiener_filter(
+            y_spec = delay_spectrum_wiener_filter(
                 np.fft.fftshift(delay_ps[lbi, :]),
                 data,
                 self.ndelay,
@@ -1088,7 +1088,7 @@ def _compute_delay_spectrum_inputs(data, N, Ni, fsel, window, complex_timedomain
     """Compute quantities needed for Gibbs sampling and/or Wiener filtering.
 
     These quantities are needed by both :func:`delay_spectrum_gibbs` and
-    :func:`wiener_filter`, so we compute them in this separate routine.
+    :func:`delay_spectrum_wiener_filter`, so we compute them in this separate routine.
     """
 
     total_freq = N if complex_timedomain else N // 2 + 1
@@ -1305,7 +1305,7 @@ def delay_spectrum_gibbs(
     return spec
 
 
-def wiener_filter(
+def delay_spectrum_wiener_filter(
     delay_PS, data, N, Ni, window="nuttall", fsel=None, complex_timedomain=False
 ):
     """Estimate the delay spectrum from an input frequency spectrum by Wiener filtering.

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2340,10 +2340,18 @@ class DelaySpectrum(ContainerBase):
         }
     }
 
+    def __init__(self, weight_boost=1.0, *args, **kwargs):
+        super(DelaySpectrum, self).__init__(*args, **kwargs)
+        self.attrs["weight_boost"] = weight_boost
+
     @property
     def spectrum(self):
         """Get the spectrum dataset."""
         return self.datasets["spectrum"]
+
+    @property
+    def weight_boost(self):
+        return self.attrs["weight_boost"]
 
 
 class DelayTransform(ContainerBase):
@@ -2368,9 +2376,17 @@ class DelayTransform(ContainerBase):
         }
     }
 
+    def __init__(self, weight_boost=1.0, *args, **kwargs):
+        super(DelayTransform, self).__init__(*args, **kwargs)
+        self.attrs["weight_boost"] = weight_boost
+
     @property
     def spectrum(self):
         return self.datasets["spectrum"]
+
+    @property
+    def weight_boost(self):
+        return self.attrs["weight_boost"]
 
 
 class Powerspectrum2D(ContainerBase):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2353,6 +2353,11 @@ class DelaySpectrum(ContainerBase):
     def weight_boost(self):
         return self.attrs["weight_boost"]
 
+    @property
+    def freq(self):
+        """Get the frequency axis of the input data."""
+        return self.attrs["freq"]
+
 
 class DelayTransform(ContainerBase):
     """Container for a delay spectrum.
@@ -2387,6 +2392,11 @@ class DelayTransform(ContainerBase):
     @property
     def weight_boost(self):
         return self.attrs["weight_boost"]
+
+    @property
+    def freq(self):
+        """Get the frequency axis of the input data."""
+        return self.attrs["freq"]
 
 
 class Powerspectrum2D(ContainerBase):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2318,7 +2318,6 @@ class DelaySpectrum(ContainerBase):
 
     Notes
     -----
-
     A note about definitions: for a dataset with a frequency axis, the corresponding
     delay spectrum is the result of Fourier transforming in frequency, while the delay
     power spectrum is obtained by taking the squared magnitude of each element of the
@@ -2351,6 +2350,11 @@ class DelaySpectrum(ContainerBase):
 
     @property
     def weight_boost(self):
+        """Get the weight boost factor.
+
+        If set, this factor was used to set the assumed noise when computing the
+        spectrum.
+        """
         return self.attrs["weight_boost"]
 
     @property
@@ -2364,7 +2368,6 @@ class DelayTransform(ContainerBase):
 
     Notes
     -----
-
     See the docstring for :py:class:`~draco.core.containers.DelaySpectrum` for a
     description of the difference between `DelayTransform` and `DelaySpectrum`.
     """
@@ -2387,10 +2390,16 @@ class DelayTransform(ContainerBase):
 
     @property
     def spectrum(self):
+        """Get the spectrum dataset."""
         return self.datasets["spectrum"]
 
     @property
     def weight_boost(self):
+        """Get the weight boost factor.
+
+        If set, this factor was used to set the assumed noise when computing the
+        spectrum.
+        """
         return self.attrs["weight_boost"]
 
     @property

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2314,7 +2314,19 @@ class DelayCutoff(ContainerBase):
 
 
 class DelaySpectrum(ContainerBase):
-    """Container for a delay power spectrum."""
+    """Container for a delay power spectrum.
+
+    Notes
+    -----
+
+    A note about definitions: for a dataset with a frequency axis, the corresponding
+    delay spectrum is the result of Fourier transforming in frequency, while the delay
+    power spectrum is obtained by taking the squared magnitude of each element of the
+    delay spectrum, and then usually averaging over some other axis. Our unfortunate
+    convention is to store a delay power spectrum in a `DelaySpectrum` container, and
+    store a delay spectrum in a :py:class:`~draco.core.containers.DelayTransform`
+    container.
+    """
 
     _axes = ("baseline", "delay")
 
@@ -2331,6 +2343,33 @@ class DelaySpectrum(ContainerBase):
     @property
     def spectrum(self):
         """Get the spectrum dataset."""
+        return self.datasets["spectrum"]
+
+
+class DelayTransform(ContainerBase):
+    """Container for a delay spectrum.
+
+    Notes
+    -----
+
+    See the docstring for :py:class:`~draco.core.containers.DelaySpectrum` for a
+    description of the difference between `DelayTransform` and `DelaySpectrum`.
+    """
+
+    _axes = ("baseline", "sample", "delay")
+
+    _dataset_spec = {
+        "spectrum": {
+            "axes": ["baseline", "sample", "delay"],
+            "dtype": np.complex128,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        }
+    }
+
+    @property
+    def spectrum(self):
         return self.datasets["spectrum"]
 
 


### PR DESCRIPTION
This is meant to supersede #176 and #216:
- Refactors `DelaySpectrumEstimator`, `DelaySpectrumEstimatorBase`, and `DelaySpectrumWienerBase` to eliminate repeated code blocks and enable future extensions
- Implements the fixes and features from #216 

Notably, I've kept the scheme of compressing many axes into a `baseline` axis. I don't think this is ideal in the long run, but in the short term, I think it's higher-priority to get the Wiener filter and #216 features all merged coherently