### PR TITLE
Timestamp fixes (1/1): Remove some unnecessary time axis copies

### DIFF
--- a/draco/analysis/sensitivity.py
+++ b/draco/analysis/sensitivity.py
@@ -230,7 +230,6 @@ class ComputeSystemSensitivity(task.SingleTask):
         # Create output container
         metrics = containers.SystemSensitivity(
             pol=np.array(pol_uniq, dtype="<U2"),
-            time=data.time[:],
             axes_from=data,
             attrs_from=data,
             comm=data.comm,

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -211,13 +211,6 @@ class CollateProducts(task.SingleTask):
             ss_prod = ss.prod
             ss_conj = np.zeros(ss_prod.size, dtype=bool)
 
-        # Add the time-like axis to the kwargs
-        output_kwargs = (
-            {"ra": ss.ra[:]}
-            if isinstance(ss, containers.SiderealStream)
-            else {"time": ss.time[:]}
-        )
-
         # Create output container
         sp = ss.__class__(
             freq=bt_freq,
@@ -228,7 +221,6 @@ class CollateProducts(task.SingleTask):
             copy_from=ss,
             distributed=True,
             comm=ss.comm,
-            **output_kwargs,
         )
 
         # Check if frequencies are already ordered

--- a/draco/synthesis/gain.py
+++ b/draco/synthesis/gain.py
@@ -42,7 +42,7 @@ class BaseGains(task.SingleTask):
 
         time = data.time
 
-        gain_data = containers.GainData(time=time, axes_from=data, comm=data.comm)
+        gain_data = containers.GainData(axes_from=data, comm=data.comm)
         gain_data.redistribute("input")
 
         # Save some useful attributes


### PR DESCRIPTION
Instead, the copy_from parameter will handle directly copying all index_map entries, including the time axis.