### PR TITLE
Extend ContainerBase _axes attribute to allow added axis specs

### DIFF
--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -143,13 +143,29 @@ class SiderealGrouper(task.SingleTask):
         self.log.info("Constructing LSD:%i [%i files]", lsd, len(self._timestream_list))
 
         # Construct the combined timestream
-        ts = tod.concatenate(self._timestream_list)
+        ts = concatenate_tod(self._timestream_list)
 
         # Add attributes for the LSD and a tag for labelling saved files
         ts.attrs["tag"] = "lsd_%i" % lsd
         ts.attrs["lsd"] = lsd
 
         return ts
+
+
+def concatenate_tod(data_list, *args, **kwargs):
+    """Concatenate time-ordered data and copy axis specs.
+
+    This is defined to handle some behaviour specific to draco
+    containers. See `caput.tod.concatenate` documentation for more.
+    """
+    # Concatenate the timestreams
+    ts = tod.concatenate(data_list, *args, **kwargs)
+
+    # Copy over axis specs
+    if hasattr(ts, "axes_spec"):
+        ts._copy_axes_spec(data_list[0])
+
+    return ts
 
 
 class SiderealRegridder(Regridder):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -803,7 +803,8 @@ class VisContainer(ContainerBase):
             kwargs["stack"] = stack
 
         # Call initializer from `ContainerBase`
-        super(VisContainer, self).__init__(*args, **kwargs)
+        # super(VisContainer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         reverse_map_stack = None
         # Create reverse map

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -551,7 +551,7 @@ class ContainerBase(memh5.BasicCont):
                         # Check if this is produces the axis map that
                         # we got. If it does, we should inherit the
                         # axis from the index_map
-                        if np.array_equal(axis_map, from_attr):
+                        if np.array_equal(np.asarray(axis_map), np.asarray(from_attr)):
                             return axes_from.index_map.get(axis, axis_map)
 
                         # Not a match


### PR DESCRIPTION
The idea here is that _axes can optionally be defined as a dict, allowing definitions of axis specs (i.e., time alignment convention for the time axis). These specs are then copied over when using axes_from or copy_from, so, for example, if CHIMETimeStream defines a different spec from the default in `TODContainer`, any container which inherits from `CHIMETimeStream` will also inherit the modified spec. 

The behaviour of all existing properties remains the same, although this does modify the `_axes` property of the instance (i.e., typically a `TimeStream` container doesn't define anything in its class `_axes`, since the various axes are inherited from other classes. Thus, the `.axes` property will return a tuple of all inherited axes, whereas the `._axes` property is empty. This change means that the `._axes` property would now include a "time" entry which is copied from the `axes_from` container if any spec is defined on `axes_from`).

This combined with #222 and chime-experiment/ch_pipeline#167 will fix the issues in chime-experiment/ch_pipeline#146