### PR TITLE
Timestamp Alignment(2/4): Copy index_map dataset attributes and remove `time` property

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -744,26 +744,6 @@ class TODContainer(ContainerBase, tod.TOData):
 
     _axes = ("time",)
 
-    @property
-    def time(self):
-        """The actual times associated with each entry of the time axis.
-
-        By convention this property should return the floating point UTC UNIX time in
-        seconds for the *centre* of each time sample.
-        """
-        try:
-            time = self.index_map["time"][:]["ctime"]
-        # Need to check for both types as different numpy versions return
-        # different exceptions.
-        except (IndexError, ValueError):
-            time = self.index_map["time"][:]
-
-        # This method should always return the time centres, so a shift is applied
-        # based on the time index_map entry alignment
-        alignment = self.index_attrs["time"].get("alignment", 0)
-
-        return time + alignment * (abs(np.median(np.diff(time))) / 2)
-
 
 class VisContainer(ContainerBase):
     """A base container for holding a visibility dataset.

--- a/test/test_containers.py
+++ b/test/test_containers.py
@@ -16,6 +16,7 @@ def ss_container():
     ss.attrs["test_attr1"] = "hello"
     ss.vis.attrs["test_attr2"] = "hello2"
     ss.weight.attrs["test_attr3"] = "hello3"
+    ss.index_attrs["freq"]["alignment"] = 1
 
     return ss
 
@@ -28,6 +29,7 @@ def test_attrs_from(ss_container):
     assert ts.attrs["test_attr1"] == "hello"
     assert ts.vis.attrs["test_attr2"] == "hello2"
     assert ts.weight.attrs["test_attr3"] == "hello3"
+    assert ts.index_attrs["freq"]["alignment"] == 1
 
     # Check that the axis attributes on the datasets did not get overwritten
     assert len(ts.vis.attrs) == 2
@@ -50,6 +52,7 @@ def test_copy(ss_container):
     assert ss_copy.attrs["test_attr1"] == "hello"
     assert ss_copy.vis.attrs["test_attr2"] == "hello2"
     assert ss_copy.weight.attrs["test_attr3"] == "hello3"
+    assert ss_copy.index_attrs["freq"]["alignment"] == 1
 
     # Check the chunking parameters
     assert ss_copy.vis.chunks == ss_container.vis.chunks


### PR DESCRIPTION
`index_map` dataset attributes will be copied when `axes_from` is set. The `.time` property is removed from `containers.TODContainer` as it will be moved to `caput.tod.TOData`.

Related PRs:
- https://github.com/radiocosmology/caput/pull/234
- https://github.com/chime-experiment/ch_pipeline/pull/168
- https://github.com/chime-experiment/ch_util/pull/52

Note: this PR will not pass CI checks until the `caput` PR is merged

Another note: This raises a deprecation warning from `numpy.array_equal`. This is an internal numpy issue and should be fixed in numpy 1.24 (we're running 1.22.2 on cedar)