### PR TITLE
fix(flagging): increase default threshold for static weight masking

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -627,8 +627,8 @@ class SanitizeWeights(task.SingleTask):
         smallest value to keep
     """
 
-    max_thresh = config.Property(proptype=np.float32, default=1e10)
-    min_thresh = config.Property(proptype=np.float32, default=1e-10)
+    max_thresh = config.Property(proptype=np.float32, default=1e30)
+    min_thresh = config.Property(proptype=np.float32, default=1e-30)
 
     def setup(self):
         """Validate the max and min values.

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -445,10 +445,6 @@ class MaskBadGains(task.SingleTask):
             data.gain[:] <= self.threshold + self.threshold_tol, axis=1
         ).allgather()
 
-        # Log the percent of data masked
-        drop_frac = 100.0 * mask.sum() / mask.size
-        self.log.info(f"Flagging {drop_frac:.2f}% of data due to bad gains.")
-
         mask_cont = containers.RFIMask(axes_from=data)
         mask_cont.mask[:] = mask
 


### PR DESCRIPTION
Since this is just supposed to catch numerical issues, I'm moving the default thresholds much closer to the max/min float32 values.

I'm also interested in feedback about making this baseline-independent and just spitting out  a mask, since it's adding some baseline-dependent flagging at the moment.