### PR TITLE
feat(beam): use GridBeam in telescope coordinates

### DIFF
--- a/draco/analysis/beam.py
+++ b/draco/analysis/beam.py
@@ -16,6 +16,7 @@ Tasks
 
 import numpy as np
 import scipy.constants
+import scipy.interpolate
 
 from caput import interferometry
 
@@ -45,6 +46,9 @@ class CreateBeamStream(task.SingleTask):
             % (self.telescope.latitude, self.telescope.rotation_angle)
         )
 
+        self.latitude = np.radians(self.telescope.latitude)
+        self.rotation_angle = np.radians(self.telescope.rotation_angle)
+
     def process(self, data, beam):
         """Convert the beam model into a format that can be deconvolved from data.
 
@@ -69,48 +73,50 @@ class CreateBeamStream(task.SingleTask):
 
         freq = beam.freq[fstart:fstop]
 
-        # Make sure the beam is in celestial coordinates
-        if beam.coords != "celestial":
-            raise RuntimeError(
-                "Beam must be converted to celestial coordinates prior to generating "
-                "a HybridVisStream."
-            )
-
-        # Check that el matches
-        dec = beam.theta
-
-        el_beam = np.sin(np.radians(dec - self.telescope.latitude))
+        # Extract the coordinates
         el_data = data.index_map["el"]
 
+        if beam.coords == "celestial":
+            dec = np.radians(beam.theta)
+            el_beam = np.sin(dec - self.latitude)
+
+            ha = beam.phi
+            ra = (ha + 360.0) % 360.0
+            nra = int(round(360.0 / np.abs(ha[1] - ha[0])))
+            delta_ra = 360.0 / nra
+
+            map_ra = np.rint(ra / delta_ra).astype(int)
+
+            # Test that the positions of the original beam samples are close enough to exact
+            # grid locations in the output grid. This 1e-4 number tolerance is just a guess
+            # as to what is reasonable.
+            if not np.allclose(ra / delta_ra, map_ra, atol=1e-4):
+                raise ValueError(
+                    "Input beam cannot be placed on an grid between 0 and 360 degrees."
+                )
+
+            ha = np.radians(ha)
+
+        elif beam.coords == "telescope":
+            el_beam = beam.theta
+            dec = np.arcsin(el_beam) + self.latitude
+
+            ra = data.ra
+            ha = np.radians(((ra + 180.0) % 360.0) - 180.0)
+
+        else:
+            raise RuntimeError(f"Do not recognize {beam.coords} coordinate system.")
+
+        # Make sure that el matches
         if not np.allclose(el_beam, el_data):
             raise RuntimeError("The el axis for the beam and data do not match.")
 
-        # Map the RAs
-        ha = beam.phi
-        ra_beam = (ha + 360.0) % 360.0
-        nra = int(round(360.0 / np.abs(ha[1] - ha[0])))
-        delta_ra = 360.0 / nra
-
-        map_ra = np.rint(ra_beam / delta_ra).astype(int)
-
-        # Test that the positions of the original beam samples are close enough to exact
-        # grid locations in the output grid. This 1e-4 number tolerance is just a guess
-        # as to what is reasonable.
-        if not np.allclose(ra_beam / delta_ra, map_ra, atol=1e-4):
-            raise ValueError(
-                "Input beam cannot be placed on an grid between 0 and 360 degrees."
-            )
-
-        # Determine other axes
+        # Determine baseline distances
         x = data.index_map["ew"][:]
 
-        arr_ha = np.radians(ha[np.newaxis, np.newaxis, np.newaxis, :])
-        arr_dec = np.radians(dec[np.newaxis, np.newaxis, :, np.newaxis])
-
-        # Determine baseline distances
         lmbda = scipy.constants.c * 1e-6 / freq
         u = x[np.newaxis, :] / lmbda[:, np.newaxis]
-        u = u[:, :, np.newaxis, np.newaxis]
+        u = u[:, :, np.newaxis]
 
         # Rotate the baseline distances by the telescope's rotation angle.
         # This assumes that the baseline distances used to beamform in the
@@ -119,30 +125,24 @@ class CreateBeamStream(task.SingleTask):
         # correct for the rotation in this way, since we have already collapsed
         # over NS baselines. However, this partial correction should be pretty good
         # for small rotation angles and for sources near meridian.
-        rot = np.radians(self.telescope.rotation_angle)
-        v = np.sin(rot) * u
-        u = np.cos(rot) * u
-
-        # Calculate the phase
-        phi = interferometry.fringestop_phase(
-            arr_ha, np.radians(self.telescope.latitude), arr_dec, u, v
-        ).conj()
+        v = np.sin(self.rotation_angle) * u
+        u = np.cos(self.rotation_angle) * u
 
         # Reshape the beam datasets to match the output container.
         # The output weight dataset does not have an el axis, use the
         # average non-zero value of the weight along the el direction.
-        bweight = beam.weight[:]
+        bweight = beam.weight[:].local_array
         bweight = np.sum(bweight, axis=-2) * tools.invert_no_zero(
             np.sum(bweight > 0, axis=-2, dtype=np.float32)
         )
 
         # Transpose the first two dimensions from (freq, pol) to (pol, freq)
         bweight = bweight.swapaxes(0, 1)
-        bvis = beam.beam[:].swapaxes(0, 1)
+        bvis = beam.beam[:].local_array.swapaxes(0, 1)
 
         # Create output container
         out = containers.HybridVisStream(
-            ra=nra,
+            ra=ra,
             axes_from=data,
             attrs_from=data,
             distributed=data.distributed,
@@ -153,8 +153,73 @@ class CreateBeamStream(task.SingleTask):
         for dset in out.datasets.values():
             dset[:] = 0.0
 
-        out.weight[:][..., map_ra] = bweight
-        out.vis[:][..., map_ra] = bvis * phi[np.newaxis, ...]
+        oweight = out.weight[:].local_array
+        ovis = out.vis[:].local_array
+
+        # Use a different procedure for a beam in celestial
+        # versus telescope coordinates.
+        if beam.coords == "celestial":
+            # Calculate the phase
+            phi = interferometry.fringestop_phase(
+                ha[np.newaxis, np.newaxis, np.newaxis, :],
+                self.latitude,
+                dec[np.newaxis, np.newaxis, :, np.newaxis],
+                u[:, :, np.newaxis, :],
+                v[:, :, np.newaxis, :],
+            ).conj()
+
+            # Save the beam times the phase to the output stream
+            # at the appropriate right ascensions
+            oweight[..., map_ra] = bweight
+            ovis[..., map_ra] = bvis * phi[np.newaxis, ...]
+
+        else:  # beam.coords == "telescope"
+            # Extract telescope x for the beam
+            bx = beam.phi
+            span_bx = np.percentile(bx, [0, 100])
+
+            # The x coordinate must be monotonically increasing
+            # in order to create a CubicSpline.
+            if bx[0] > bx[1]:
+                bx = bx[::-1]
+                bvis = bvis[..., ::-1]
+
+            # Set the weight for the stream equal to the average non-zero weight over x
+            # We will be interpolating over this dimension.
+            bweight = np.sum(bweight, axis=-1, keepdims=True) * tools.invert_no_zero(
+                np.sum(bweight > 0, axis=-1, keepdims=True, dtype=np.float32)
+            )
+
+            # Loop over declinations
+            for dd, dc in enumerate(dec):
+                # Create a CubicSpline interpolator for the beam at this declination
+                # as a function of the telescope x coordinate
+                binterpolator = scipy.interpolate.CubicSpline(
+                    bx, bvis[..., dd, :], axis=-1, bc_type="clamped", extrapolate=True
+                )
+
+                # Calculate the x coordinate of the stream
+                dx = -1 * np.cos(dc) * np.sin(ha)
+
+                # Only bother to generate the stream if the x coordinate
+                # is within the range spanned by the beam and the hour
+                # angle is less than 90 degrees (to avoid evaluating
+                # the antipodal transit).
+                valid = np.flatnonzero(
+                    (dx >= span_bx[0])
+                    & (dx <= span_bx[1])
+                    & (np.abs(ha) < (0.5 * np.pi))
+                )
+
+                # Calculate the phase
+                phi = interferometry.fringestop_phase(
+                    ha[np.newaxis, np.newaxis, valid], self.latitude, dc, u, v
+                ).conj()
+
+                # Interpolate the beam to the x coordinates at this declination
+                # and then multiply by the phase
+                ovis[..., dd, valid] = binterpolator(dx[valid]) * phi[np.newaxis, ...]
+                oweight[..., valid] = bweight
 
         return out
 


### PR DESCRIPTION
Allows the user to generate a HybridVisStream from a GridBeam in telescope coordinates.  This avoids problems at the pole when using GridBeams in celestial coordinates that do not span 360 degrees in hour angle.