### PR TITLE
feat(transform): task to apply reduction ops to a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # C extensions
 *.so
+*.c
 
 # Packages
 *.egg

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -319,7 +319,7 @@ class CollateProducts(task.SingleTask):
 
         # Copy over any additional datasets that need to be frequency filtered
         containers.copy_datasets_filter(
-            ss, sp, "freq", freq_ind, ["input", "prod", "stack"], allow_distributed=True
+            ss, sp, "freq", freq_ind, ["input", "prod", "stack"]
         )
 
         # Switch back to frequency distribution. This will have minimal

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -226,14 +226,10 @@ class CollateProducts(task.SingleTask):
         # Check if frequencies are already ordered
         no_redistribute = freq_ind == list(range(len(ss.freq[:])))
 
-        # Add gain dataset.
-        # if 'gain' in ss.datasets:
-        #     sp.add_dataset('gain')
-
         # If frequencies are mapped across ranks, we have to redistribute so all
         # frequencies and products are on each rank
         raxis = "freq" if no_redistribute else ["ra", "time"]
-        self.log.info(f"Distributing across '{raxis}' axis")
+        self.log.debug(f"Distributing across '{raxis}' axis")
         ss.redistribute(raxis)
         sp.redistribute(raxis)
 
@@ -241,11 +237,6 @@ class CollateProducts(task.SingleTask):
         sp.vis[:] = 0.0
         sp.weight[:] = 0.0
         sp.input_flags[:] = ss.input_flags[rev_input_ind, :]
-
-        # The gain transfer below fails when distributed over multiple nodes,
-        # have to debug.
-        # if 'gain' in ss.datasets:
-        #     sp.gain[:] = ss.gain[freq_ind][:, rev_input_ind, :]
 
         # Infer number of products that went into each stack
         if self.weight != "inverse_variance":

--- a/test/test_containers.py
+++ b/test/test_containers.py
@@ -81,3 +81,63 @@ def test_copy(ss_container):
 
     assert ss_copy.vis.local_shape == ss_container.vis.local_shape
     assert ss_copy.weight.local_shape == current_shape
+
+
+def test_copy_filter(ss_container):
+    """Test copying datasets between container while filtering an axis.
+
+    This test should ensure that slices and selections can be appplied to
+    various axes properly, that arguments can be passed correctly, and that
+    the function fails as expected when bad arguments are provided.
+    """
+    new = containers.SiderealStream(axes_from=ss_container, attrs_from=ss_container)
+
+    # Test some selections which should work
+    for sel in (slice(None), slice(0, 16, 1), list(range(16)), slice(0, 30)):
+        # These should all pass
+        containers.copy_datasets_filter(ss_container, new, "ra", {"ra": sel})
+
+    # No selections
+    containers.copy_datasets_filter(ss_container, new, [], {})
+
+    # Force redistribution and downselection
+    new = containers.SiderealStream(
+        axes_from=ss_container, attrs_from=ss_container, ra=5
+    )
+
+    new.redistribute("stack")
+    ss_container.redistribute("ra")
+    containers.copy_datasets_filter(ss_container, new, ("ra",), {"ra": slice(0, 5)})
+
+    new.redistribute("freq")
+    ss_container.redistribute("ra")
+    containers.copy_datasets_filter(ss_container, new, ["ra"], {"ra": [0, 3, 4, 6, 9]})
+
+    # This should faily due to a mismatch in axis and selection arguments
+    with pytest.raises(ValueError):
+        containers.copy_datasets_filter(
+            ss_container, new, ["freq"], {"ra": slice(None)}
+        )
+
+    # Some multi-axis selections
+    new = containers.SiderealStream(
+        axes_from=ss_container, attrs_from=ss_container, ra=2, freq=2
+    )
+
+    # This should pass since there is an axis available for redistribution
+    containers.copy_datasets_filter(
+        ss_container,
+        new,
+        selection={"ra": [0, 2], "freq": [0, 4]},
+    )
+
+    new = containers.SiderealStream(
+        axes_from=ss_container, attrs_from=ss_container, ra=2, freq=2, stack=2
+    )
+    # This should fail since there is no axis available to redistribute
+    with pytest.raises(ValueError):
+        containers.copy_datasets_filter(
+            ss_container,
+            new,
+            selection={"ra": [0, 2], "freq": [0, 4], "stack": [0, 2]},
+        )


### PR DESCRIPTION
Apply a reduction op across up to n-1 axes of a rank-n dataset. The reduction can be applied to more than one dataset in the container, and axis downselection can be applied to n-1 axes as well. A weight mask can optionally be generated, which masks values where the weights are zero and is broadcast to the dataset shape if possible. This mask can also be applied before doing the reduction, using a masked array.

The task tries to optimize redistribution by first trying to minimize the number of redistributions that happen and then trying to choose the best possible axes to redistribute over if needed. This is just being done by an inverse sort by axis length.

I've tested this a fair bit, but I wouldn't be surprised if there are still some edge cases that could break. It generally works as expected when being used to generate variance-over-freq and variance-over-el datasets in the chime daily pipeline.

Requires radiocosmology/caput#242