### PR TITLE
ci(ruff): add extra linting rules: isort, pyupgrade, numpy, ruff-specific

### DIFF
--- a/draco/analysis/beam.py
+++ b/draco/analysis/beam.py
@@ -16,12 +16,9 @@ Tasks
 
 import numpy as np
 import scipy.constants
-
 from caput import interferometry
 
-from ..core import task
-from ..core import io
-from ..core import containers
+from ..core import containers, io, task
 from ..util import tools
 
 
@@ -41,8 +38,8 @@ class CreateBeamStream(task.SingleTask):
         self.telescope = io.get_telescope(telescope)
 
         self.log.info(
-            "Using telescope at latitude %0.4f deg with rotation angle %0.4f deg."
-            % (self.telescope.latitude, self.telescope.rotation_angle)
+            f"Using telescope at latitude {self.telescope.latitude:.4f} "
+            f"deg with rotation angle {self.telescope.rotation_angle:.4f} deg."
         )
 
     def process(self, data, beam):

--- a/draco/analysis/beamform.py
+++ b/draco/analysis/beamform.py
@@ -1,20 +1,23 @@
 """Beamform visibilities to the location of known sources."""
 
 from typing import Tuple
+
 import healpy
 import numpy as np
 import scipy.interpolate
-from skyfield.api import Star, Angle
-
 from caput import config
 from caput import time as ctime
-
 from cora.util import units
+from skyfield.api import Angle, Star
 
-from ..core import task, containers, io
+from ..core import containers, io, task
 from ..util._fast_tools import beamform
-from ..util.tools import baseline_vector, polarization_map, invert_no_zero
-from ..util.tools import calculate_redundancy
+from ..util.tools import (
+    baseline_vector,
+    calculate_redundancy,
+    invert_no_zero,
+    polarization_map,
+)
 
 # Constants
 NU21 = units.nu21
@@ -676,7 +679,7 @@ class BeamForm(BeamFormBase):
             Catalog of points to beamform at.
 
         """
-        super(BeamForm, self).setup(manager)
+        super().setup(manager)
         self.catalog = source_cat
 
     def process(self, data):
@@ -700,7 +703,7 @@ class BeamForm(BeamFormBase):
             return None
 
         # Call generic process method.
-        return super(BeamForm, self).process()
+        return super().process()
 
 
 class BeamFormCat(BeamFormBase):
@@ -718,7 +721,7 @@ class BeamFormCat(BeamFormBase):
             Data to beamform on.
 
         """
-        super(BeamFormCat, self).setup(manager)
+        super().setup(manager)
 
         # Process and make available various data
         self._process_data(data)
@@ -742,7 +745,7 @@ class BeamFormCat(BeamFormBase):
             return None
 
         # Call generic process method.
-        return super(BeamFormCat, self).process()
+        return super().process()
 
 
 class BeamFormExternalBase(BeamFormBase):

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -3,13 +3,12 @@
 import typing
 
 import numpy as np
-from numpy.lib.recfunctions import structured_to_unstructured
 import scipy.linalg as la
-
-from caput import mpiarray, config
+from caput import config, mpiarray
 from cora.util import units
+from numpy.lib.recfunctions import structured_to_unstructured
 
-from ..core import containers, task, io
+from ..core import containers, io, task
 from ..util import random, tools
 
 
@@ -430,9 +429,7 @@ class DelayTransformBase(task.SingleTask):
 
         # Evaluate frequency->delay transform. (self._evaluate take the empty output
         # container, fills it, and returns it)
-        out_cont = self._evaluate(data_view, weight_view, out_cont)
-
-        return out_cont
+        return self._evaluate(data_view, weight_view, out_cont)
 
     def _process_data(self, ss):
         """Get relevant views of data and weights, and create output container.
@@ -1268,8 +1265,7 @@ def delay_power_spectrum_gibbs(
         Ci = np.identity(2 * Ni.shape[0]) + np.dot(R, Rt)
         x = la.solve(Ci, y, sym_pos=True)
 
-        s = Sh[:, np.newaxis] * (np.dot(Rt, x) + w1)
-        return s
+        return Sh[:, np.newaxis] * (np.dot(Rt, x) + w1)
 
     def _draw_ps_sample(d):
         # Draw a random delay power spectrum sample assuming the signal is Gaussian and
@@ -1285,9 +1281,7 @@ def delay_power_spectrum_gibbs(
         df = d.shape[1]
         chi2 = rng.chisquare(df, size=d.shape[0])
 
-        S_samp = S_hat * df / chi2
-
-        return S_samp
+        return S_hat * df / chi2
 
     # Select the method to use for the signal sample based on how many frequencies
     # versus delays there are
@@ -1483,4 +1477,4 @@ def _take_view(arr: np.ndarray, ind: int, axis: int) -> np.ndarray:
     # Like np.take but returns a view (instead of a copy), but only supports a scalar
     # index
     sl = (slice(None),) * axis
-    return arr[sl + (ind,)]
+    return arr[(*sl, ind)]

--- a/draco/analysis/fgfilter.py
+++ b/draco/analysis/fgfilter.py
@@ -2,9 +2,9 @@
 
 
 import numpy as np
-
 from caput import config
-from ..core import task, containers, io
+
+from ..core import containers, io, task
 
 
 class _ProjectFilterBase(task.SingleTask):
@@ -40,6 +40,8 @@ class _ProjectFilterBase(task.SingleTask):
 
         if self.mode == "filter":
             return self._backward(self._forward(inp))
+
+        return None
 
     def _forward(self, inp):
         pass
@@ -170,8 +172,8 @@ class KLModeProject(_ProjectFilterBase):
         # Check and set the KL basis we are using
         if self.klname not in self.product_manager.kltransforms:
             raise RuntimeError(
-                "Requested KL basis %s not available (options are %s)"
-                % (self.klname, repr(list(self.product_manager.kltransforms.items())))
+                f"Requested KL basis {self.kname} not available (options "
+                f"are {list(self.product_manager.kltransforms.items())!r})"
             )
         kl = self.product_manager.kltransforms[self.klname]
 
@@ -208,8 +210,8 @@ class KLModeProject(_ProjectFilterBase):
         # Check and set the KL basis we are using
         if self.klname not in self.product_manager.kltransforms:
             raise RuntimeError(
-                "Requested KL basis %s not available (options are %s)"
-                % (self.klname, repr(list(self.product_manager.kltransforms.items())))
+                f"Requested KL basis {self.klname} not available (options "
+                f"are {list(self.product_manager.kltransforms.items())!r})"
             )
         kl = self.product_manager.kltransforms[self.klname]
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -7,16 +7,15 @@ The convention for flagging/masking is `True` for contaminated samples that shou
 be excluded and `False` for clean samples.
 """
 
-from typing import Union, overload
 import warnings
+from typing import Union, overload
+
 import numpy as np
 import scipy.signal
+from caput import config, mpiarray, weighted_median
 
-from caput import config, weighted_median, mpiarray
-
-from ..core import task, containers, io
-from ..util import tools
-from ..util import rfi
+from ..core import containers, io, task
+from ..util import rfi, tools
 
 
 class DayMask(task.SingleTask):
@@ -1223,9 +1222,7 @@ class RFISensitivityMask(task.SingleTask):
         nobaseflagsir = rfi.sir(nobaseflag[:, np.newaxis, :], eta=eta)[:, 0, :]
 
         # Make sure the original mask (including baseflag) is still masked
-        flagsir = nobaseflagsir | mask
-
-        return flagsir
+        return nobaseflagsir | mask
 
     def _mad_tv_mask(self, data, start_flag, freq):
         """Use the specific scattered TV channel flagging."""
@@ -1686,7 +1683,7 @@ class MaskFreq(task.SingleTask):
 
         # Solve to find a value of f that minimises the amount of data masked
         res = minimize_scalar(
-            fmask, method="golden", options=dict(maxiter=20, xtol=1e-2)
+            fmask, method="golden", options={"maxiter": 20, "xtol": 1e-2}
         )
 
         if not res.success:

--- a/draco/analysis/mapmaker.py
+++ b/draco/analysis/mapmaker.py
@@ -1,9 +1,9 @@
 """Map making from driftscan data using the m-mode formalism."""
 
 import numpy as np
-from caput import mpiarray, config
+from caput import config, mpiarray
 
-from ..core import containers, task, io
+from ..core import containers, io, task
 from ..util import tools
 
 
@@ -164,9 +164,7 @@ class DirtyMapMaker(BaseMapMaker):
         a = np.dot(bm.T.conj(), Ni * v)
 
         # Reshape to the correct output
-        a = a.reshape(bt.telescope.num_pol_sky, bt.telescope.lmax + 1)
-
-        return a
+        return a.reshape(bt.telescope.num_pol_sky, bt.telescope.lmax + 1)
 
 
 class MaximumLikelihoodMapMaker(BaseMapMaker):
@@ -199,9 +197,7 @@ class MaximumLikelihoodMapMaker(BaseMapMaker):
         a = np.dot(ib, Nh * v)
 
         # Reshape to the correct output
-        a = a.reshape(bt.telescope.num_pol_sky, bt.telescope.lmax + 1)
-
-        return a
+        return a.reshape(bt.telescope.num_pol_sky, bt.telescope.lmax + 1)
 
 
 class WienerMapMaker(BaseMapMaker):
@@ -300,6 +296,4 @@ def pinv_svd(M, acond=1e-4, rcond=1e-3):
 
     psigma_diag = 1.0 / sig[:rank]
 
-    B = np.transpose(np.conjugate(np.dot(u[:, :rank] * psigma_diag, vh[:rank])))
-
-    return B
+    return np.transpose(np.conjugate(np.dot(u[:, :rank] * psigma_diag, vh[:rank])))

--- a/draco/analysis/powerspectrum.py
+++ b/draco/analysis/powerspectrum.py
@@ -2,9 +2,9 @@
 
 
 import numpy as np
-
 from caput import config
-from ..core import task, containers
+
+from ..core import containers, task
 
 
 class QuadraticPSEstimation(task.SingleTask):

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -21,16 +21,13 @@ Tasks
     RADependentWeights
 """
 import numpy as np
-from numpy.lib.recfunctions import structured_to_unstructured
 import scipy.constants
-from mpi4py import MPI
-
 from caput import config
+from mpi4py import MPI
+from numpy.lib.recfunctions import structured_to_unstructured
 
-from ..core import task
-from ..core import io
+from ..core import containers, io, task
 from ..util import tools
-from ..core import containers
 from . import transform
 
 
@@ -946,11 +943,9 @@ class TikhonovRingMapMaker(DeconvolveHybridMBase):
         if self.exclude_intracyl:
             weight_ew[..., 0, :] = 0.0
 
-        weight_ew = weight_ew * tools.invert_no_zero(
+        return weight_ew * tools.invert_no_zero(
             np.sum(weight_ew, axis=-2, keepdims=True)
         )
-
-        return weight_ew
 
     def _get_regularisation(self, *args):
         return self.inv_SN

--- a/draco/analysis/sensitivity.py
+++ b/draco/analysis/sensitivity.py
@@ -1,10 +1,9 @@
 """Sensitivity Analysis Tasks."""
 
 import numpy as np
-
 from caput import config
 
-from ..core import task, io, containers
+from ..core import containers, io, task
 from ..util import tools
 
 

--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -12,13 +12,12 @@ into  :class:`SiderealGrouper`, then feeding that into
 
 import numpy as np
 import scipy.linalg as la
-
 from caput import config, mpiarray, tod
 from cora.util import units
 
-from .transform import Regridder
-from ..core import task, containers, io
+from ..core import containers, io, task
 from ..util import tools
+from .transform import Regridder
 
 
 class SiderealGrouper(task.SingleTask):
@@ -43,7 +42,7 @@ class SiderealGrouper(task.SingleTask):
     min_day_length = config.Property(proptype=float, default=0.10)
 
     def __init__(self):
-        super(SiderealGrouper, self).__init__()
+        super().__init__()
 
         self._timestream_list = []
         self._current_lsd = None
@@ -110,8 +109,8 @@ class SiderealGrouper(task.SingleTask):
             self._current_lsd = lsd_end
 
             return tstream_all
-        else:
-            return None
+
+        return None
 
     def process_finish(self):
         """Return the final sidereal day.
@@ -273,11 +272,9 @@ class SiderealRegridder(Regridder):
 
         # Construct a complex sinusoid whose frequency
         # is equal to each baselines fringe rate
-        phase = mask * np.exp(
+        return mask * np.exp(
             -1.0j * omega[:, :, np.newaxis] * dphi[np.newaxis, np.newaxis, :]
         )
-
-        return phase
 
 
 def _search_nearest(x, xeval):
@@ -286,13 +283,11 @@ def _search_nearest(x, xeval):
     index_previous = np.maximum(0, index_next - 1)
     index_next = np.minimum(x.size - 1, index_next)
 
-    index = np.where(
+    return np.where(
         np.abs(xeval - x[index_previous]) < np.abs(xeval - x[index_next]),
         index_previous,
         index_next,
     )
-
-    return index
 
 
 class SiderealRegridderNearest(SiderealRegridder):
@@ -811,7 +806,7 @@ class SiderealStackerMatch(task.SingleTask):
 
 def _ensure_list(x):
     if hasattr(x, "__iter__"):
-        y = [xx for xx in x]
+        y = list(x)
     else:
         y = [x]
 

--- a/draco/analysis/sourcestack.py
+++ b/draco/analysis/sourcestack.py
@@ -1,14 +1,13 @@
 """Source Stack Analysis Tasks."""
 
 import numpy as np
-from mpi4py import MPI
-
 from caput import config, pipeline
 from cora.util import units
+from mpi4py import MPI
 
-from ..util.tools import invert_no_zero
+from ..core import containers, task
 from ..util.random import RandomTask
-from ..core import task, containers
+from ..util.tools import invert_no_zero
 
 # Constants
 NU21 = units.nu21
@@ -367,8 +366,9 @@ class GroupSourceStacks(task.SingleTask):
         )
 
         if (len(self.stack) % self.ngroup) == 0:
-            out = self._reset()
-            return out
+            return self._reset()
+
+        return None
 
     def process_finish(self):
         """Return whatever FrequencyStacks are currently in the list.
@@ -379,8 +379,9 @@ class GroupSourceStacks(task.SingleTask):
             The remaining frequency stacks accumulated into a single container.
         """
         if len(self.stack) > 0:
-            out = self._reset()
-            return out
+            return self._reset()
+
+        return None
 
     def _reset(self):
         """Combine all frequency stacks currently in the list into new container.

--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -2,10 +2,9 @@
 
 import numpy as np
 import scipy.linalg as la
-
 from caput import config
 
-from draco.core import task, containers
+from draco.core import containers, task
 
 
 class SVDSpectrumEstimator(task.SingleTask):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -467,7 +467,7 @@ class ContainerBase(memh5.BasicCont):
         # Check if all those axes exist
         for axis in sel_args.keys():
             if axis not in cls._class_axes():
-                raise RuntimeError("No '{}' axis found to select from.".format(axis))
+                raise RuntimeError(f"No '{axis}' axis found to select from.")
 
         # Build selections dict
         selections = {}
@@ -639,7 +639,7 @@ class TableBase(ContainerBase):
         self._dataset_spec = dspec
         self._axes = axes
 
-        super(TableBase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _create_dtype(self, columns):
         """Take a dictionary of columns and turn into the appropriate compound data type."""
@@ -739,7 +739,7 @@ class VisContainer(ContainerBase):
             kwargs["stack"] = stack
 
         # Call initializer from `ContainerBase`
-        super(VisContainer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         reverse_map_stack = None
         # Create reverse map
@@ -836,7 +836,7 @@ class SampleVarianceContainer(ContainerBase):
                 dtype=[("component_a", "<U8"), ("component_b", "<U8")],
             )
 
-        super(SampleVarianceContainer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def component(self):
@@ -858,8 +858,8 @@ class SampleVarianceContainer(ContainerBase):
         """
         if "sample_variance" in self.datasets:
             return self.datasets["sample_variance"]
-        else:
-            raise KeyError("Dataset 'sample_variance' not initialised.")
+
+        raise KeyError("Dataset 'sample_variance' not initialised.")
 
     @property
     def sample_variance_iq(self):
@@ -914,8 +914,8 @@ class SampleVarianceContainer(ContainerBase):
         """Get the nsample dataset if it exists."""
         if "nsample" in self.datasets:
             return self.datasets["nsample"]
-        else:
-            raise KeyError("Dataset 'nsample' not initialised.")
+
+        raise KeyError("Dataset 'nsample' not initialised.")
 
     @property
     def sample_weight(self):
@@ -1468,7 +1468,7 @@ class GridBeam(FreqContainer):
     }
 
     def __init__(self, coords="celestial", *args, **kwargs):
-        super(GridBeam, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.attrs["coords"] = coords
 
     @property
@@ -1548,7 +1548,7 @@ class HEALPixBeam(FreqContainer, HealpixContainer):
     }
 
     def __init__(self, coords="unknown", ordering="unknown", *args, **kwargs):
-        super(HEALPixBeam, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.attrs["coords"] = coords
         self.attrs["ordering"] = ordering
 
@@ -1658,19 +1658,19 @@ class TrackBeam(FreqContainer, SampleVarianceContainer):
             if len(theta) != len(phi):
                 raise RuntimeError(
                     "theta and phi axes must have same length: "
-                    "({:d} != {:d})".format(len(theta), len(phi))
+                    f"({len(theta)} != {len(phi)})"
                 )
-            else:
-                pix = np.zeros(
-                    len(theta), dtype=[("theta", np.float32), ("phi", np.float32)]
-                )
-                pix["theta"] = theta
-                pix["phi"] = phi
-                kwargs["pix"] = pix
+
+            pix = np.zeros(
+                len(theta), dtype=[("theta", np.float32), ("phi", np.float32)]
+            )
+            pix["theta"] = theta
+            pix["phi"] = phi
+            kwargs["pix"] = pix
         elif (theta is None) != (phi is None):
             raise RuntimeError("Both theta and phi coordinates must be specified.")
 
-        super(TrackBeam, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.attrs["coords"] = coords
         self.attrs["track_type"] = track_type
@@ -2340,7 +2340,7 @@ class DelaySpectrum(ContainerBase):
     }
 
     def __init__(self, weight_boost=1.0, *args, **kwargs):
-        super(DelaySpectrum, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.attrs["weight_boost"] = weight_boost
 
     @property
@@ -2385,7 +2385,7 @@ class DelayTransform(ContainerBase):
     }
 
     def __init__(self, weight_boost=1.0, *args, **kwargs):
-        super(DelayTransform, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.attrs["weight_boost"] = weight_boost
 
     @property
@@ -2468,7 +2468,7 @@ class Powerspectrum2D(ContainerBase):
                 [centre, width], names=["centre", "width"]
             ).view(np.ndarray)
 
-        super(Powerspectrum2D, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def powerspectrum(self):
@@ -2821,10 +2821,10 @@ def empty_like(obj, **kwargs):
     """
     if isinstance(obj, ContainerBase):
         return obj.__class__(axes_from=obj, attrs_from=obj, **kwargs)
-    else:
-        raise RuntimeError(
-            "I don't know how to deal with data type %s" % obj.__class__.__name__
-        )
+
+    raise RuntimeError(
+        f"I don't know how to deal with data type {obj.__class__.__name__}"
+    )
 
 
 def empty_timestream(**kwargs):
@@ -2850,7 +2850,7 @@ def copy_datasets_filter(
     dest: ContainerBase,
     axis: Union[str, list, tuple] = [],
     selection: Union[np.ndarray, list, slice, dict] = {},
-    exclude_axes: List[str] = None,
+    exclude_axes: Optional[List[str]] = None,
 ):
     """Copy datasets while filtering a given axis.
 

--- a/draco/core/misc.py
+++ b/draco/core/misc.py
@@ -6,10 +6,9 @@ all be moved out into their own module.
 """
 
 import numpy as np
-
 from caput import config
 
-from ..core import task, containers
+from ..core import containers, task
 from ..util import tools
 
 
@@ -194,7 +193,7 @@ class AccumulateList(task.MPILoggedTask):
     """Accumulate the inputs into a list and return when the task *finishes*."""
 
     def __init__(self):
-        super(AccumulateList, self).__init__()
+        super().__init__()
         self._items = []
 
     def next(self, input_):
@@ -244,7 +243,7 @@ class CheckMPIEnvironment(task.MPILoggedTask):
         start_time = time.time()
 
         while time.time() - start_time < self.timeout:
-            success = all([r.get_status() for r in results])
+            success = all(r.get_status() for r in results)
 
             if success:
                 break

--- a/draco/synthesis/gain.py
+++ b/draco/synthesis/gain.py
@@ -2,10 +2,9 @@
 
 
 import numpy as np
-
 from caput import config, mpiarray, pipeline
 
-from ..core import containers, task, io
+from ..core import containers, io, task
 
 
 class BaseGains(task.SingleTask):
@@ -273,9 +272,7 @@ class RandomGains(BaseGains):
         self._prev_amp = gain_amp
 
         gain_amp = gain_amp.reshape((len(self.freq), ninput, ntime))
-        gain_amp = 1.0 + gain_amp
-
-        return gain_amp
+        return 1.0 + gain_amp
 
     def _generate_phase(self, time):
         # Generate the correlation function
@@ -292,9 +289,7 @@ class RandomGains(BaseGains):
         # Save phase fluctuations to instannce
         self._prev_phase = gain_phase_fluc
         # Reshape to correct size
-        gain_phase_fluc = gain_phase_fluc.reshape((len(self.freq), ninput, ntime))
-
-        return gain_phase_fluc
+        return gain_phase_fluc.reshape((len(self.freq), ninput, ntime))
 
 
 class RandomSiderealGains(RandomGains, SiderealGains):
@@ -436,7 +431,7 @@ class GainStacker(task.SingleTask):
 
 def _ensure_list(x):
     if hasattr(x, "__iter__"):
-        y = [xx for xx in x]
+        y = list(x)
     else:
         y = [x]
 
@@ -597,6 +592,4 @@ def constrained_gaussian_realisation(x, corrfunc, n, x2, y2, rcond=1e-12):
     y_r = _realisation(Ap_r, n, rcond)
 
     # Project into the original basis for A
-    y = np.dot(z_r + y_r, R_A.T)
-
-    return y
+    return np.dot(z_r + y_r, R_A.T)

--- a/draco/synthesis/mockcatalog.py
+++ b/draco/synthesis/mockcatalog.py
@@ -84,16 +84,15 @@ Below is an example workflow:
 ...
 """
 
-import numpy as np
 import healpy as hp
+import numpy as np
 import scipy.stats
-
+from caput import config, mpiarray, mpiutil
 from cora.util import units
-from caput import config
-from caput import mpiarray, mpiutil
-from ..core import task, containers
-from ..util import random, tools
 from mpi4py import MPI
+
+from ..core import containers, task
+from ..util import random, tools
 
 # Constants
 C = units.c
@@ -430,9 +429,7 @@ class PdfGeneratorUncorrelated(PdfGeneratorBase):
         z_weights = mpiarray.MPIArray.wrap(1 / gs * np.ones(ls), axis=0)
 
         # Create PDF map
-        pdf_map = self.make_pdf_map(source_map, z_weights)
-
-        return pdf_map
+        return self.make_pdf_map(source_map, z_weights)
 
 
 class PdfGeneratorWithSelectionFunction(PdfGeneratorBase):
@@ -468,9 +465,7 @@ class PdfGeneratorWithSelectionFunction(PdfGeneratorBase):
         z_weights = mpiarray.MPIArray.wrap(z_weights / z_weights_sum, axis=0)
 
         # Create PDF map
-        pdf_map = self.make_pdf_map(source_map, z_weights, selfunc)
-
-        return pdf_map
+        return self.make_pdf_map(source_map, z_weights, selfunc)
 
 
 class PdfGeneratorNoSelectionFunction(PdfGeneratorBase):
@@ -538,9 +533,7 @@ class PdfGeneratorNoSelectionFunction(PdfGeneratorBase):
             z_weights = mpiarray.MPIArray.wrap(z_weights_global[lo : lo + ls], axis=0)
 
         # Create PDF map
-        pdf_map = self.make_pdf_map(source_map, z_weights)
-
-        return pdf_map
+        return self.make_pdf_map(source_map, z_weights)
 
 
 class MockCatalogGenerator(task.SingleTask, random.RandomTask):
@@ -937,9 +930,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
 
         dv = err_func(z, self.rng)
 
-        dz = (1.0 + z) * dv / (C * 1e-3)
-
-        return dz
+        return (1.0 + z) * dv / (C * 1e-3)
 
     @staticmethod
     def qso_velocity_error(z, rng):
@@ -975,9 +966,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
         u = rng.uniform(size=nsample)
         flag = u >= (1.0 / (1.0 + QSO_F))
 
-        dv = np.where(flag, dv1, dv2)
-
-        return dv
+        return np.where(flag, dv1, dv2)
 
     @staticmethod
     def qsoalt_velocity_error(z, rng):
@@ -1029,9 +1018,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
         dv1 = rng.standard_normal(nsample) * sig1z(z)
         dv2 = rng.standard_normal(nsample) * QSO_SIG2
 
-        dv = np.where(flag, dv1, dv2)
-
-        return dv
+        return np.where(flag, dv1, dv2)
 
     @staticmethod
     def lrg_velocity_error(z, rng):
@@ -1059,9 +1046,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
         """
         LRG_SIG = 65.6
 
-        dv = rng.normal(scale=LRG_SIG, size=len(z))
-
-        return dv
+        return rng.normal(scale=LRG_SIG, size=len(z))
 
     @staticmethod
     def elg_velocity_error(z, rng):
@@ -1072,7 +1057,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
         percentiles:
             "Additionally, we can assess with repeats that 99.5, 95, and 50
             percent of our redshift estimates have a precision better than
-            300 km s−1, 100 km s−1, and 20 km s−1, respectively."
+            300 km s-1, 100 km s-1, and 20 km s-1, respectively."
         These percentiles do not follow a Gaussian, but are reasonably well fit
         by a Tukey lambda distribution if the scale and shape parameters
         are allowed to float.
@@ -1094,9 +1079,7 @@ class AddEBOSSZErrorsToCatalog(task.SingleTask, random.RandomTask):
 
         dist = scipy.stats.tukeylambda
         dist.random_state = rng
-        dv = dist.rvs(ELG_LAMBDA, scale=ELG_SIG, size=len(z))
-
-        return dv
+        return dist.rvs(ELG_LAMBDA, scale=ELG_SIG, size=len(z))
 
 
 _velocity_error_function_lookup = {

--- a/draco/synthesis/mockcatalog.py
+++ b/draco/synthesis/mockcatalog.py
@@ -84,13 +84,6 @@ Below is an example workflow:
 ...
 """
 
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import numpy as np
 import healpy as hp
 import scipy.stats

--- a/draco/synthesis/noise.py
+++ b/draco/synthesis/noise.py
@@ -10,12 +10,11 @@ using the variance of the noise estimate in the existing data.
 """
 
 import numpy as np
-
 from caput import config
 from caput.time import STELLAR_S
 
-from ..core import task, containers, io
-from ..util import tools, random
+from ..core import containers, io, task
+from ..util import random, tools
 
 
 class ReceiverTemperature(task.SingleTask):
@@ -274,6 +273,7 @@ class SampleNoise(task.SingleTask, random.RandomTask):
             The sampled (i.e. noisy) visibility dataset.
         """
         from caput.time import STELLAR_S
+
         from ..util import _fast_tools
 
         data_exp.redistribute("freq")

--- a/draco/synthesis/stream.py
+++ b/draco/synthesis/stream.py
@@ -7,11 +7,10 @@ a set of time stream files with :class:`MakeTimeStream`.
 """
 
 import numpy as np
-
+from caput import config, mpiarray, mpiutil, pipeline
 from cora.util import hputil
-from caput import mpiutil, pipeline, config, mpiarray
 
-from ..core import containers, task, io
+from ..core import containers, io, task
 
 
 class SimulateSidereal(task.SingleTask):

--- a/draco/util/random.py
+++ b/draco/util/random.py
@@ -1,13 +1,12 @@
 """Utilities for drawing random numbers."""
 
 import contextlib
-
-import numpy as np
 import zlib
 
+import numpy as np
 from caput import config
-from ..core import task
 
+from ..core import task
 
 _rng = None
 _default_bitgen = np.random.SFC64
@@ -223,6 +222,7 @@ def mpi_random_seed(seed, extra=0, gen=None):
         If we are setting the RandomGen bit_generator, it will be returned.
     """
     import warnings
+
     from caput import mpiutil
 
     warnings.warn(
@@ -306,7 +306,7 @@ class RandomTask(task.MPILoggedTask):
             # hash.
             # NOTE: the slightly odd (rank + 1) is to ensure that even rank=0 mixes in
             # the class seed
-            cls_name = "%s.%s" % (self.__module__, self.__class__.__name__)
+            cls_name = f"{self.__module__}.{self.__class__.__name__}"
             cls_seed = zlib.adler32(cls_name.encode())
             new_seed = seed + (self.comm.rank + 1) * cls_seed
 

--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -131,9 +131,7 @@ def lanczos_forward_matrix(x, y, a=5, periodic=False):
         n = len(x)
         sep = np.where(np.abs(sep) > n // 2, n - np.abs(sep), sep)
 
-    lz_forward = lanczos_kernel(sep, a)
-
-    return lz_forward
+    return lanczos_kernel(sep, a)
 
 
 def lanczos_inverse_matrix(x, y, a=5, cond=1e-1):
@@ -156,6 +154,4 @@ def lanczos_inverse_matrix(x, y, a=5, cond=1e-1):
         Lanczos regridding matrix. Apply to data with `np.dot(matrix, data)`.
     """
     lz_forward = lanczos_forward_matrix(x, y, a)
-    lz_inverse = la.pinv(lz_forward, rcond=cond)
-
-    return lz_inverse
+    return la.pinv(lz_forward, rcond=cond)

--- a/draco/util/testing.py
+++ b/draco/util/testing.py
@@ -1,8 +1,8 @@
 """draco test utils."""
 
+from caput import config, memh5, pipeline
+
 from draco.core.task import SingleTask
-from caput import pipeline, config
-from caput import memh5
 
 
 class DummyTask(SingleTask):
@@ -30,7 +30,7 @@ class DummyTask(SingleTask):
         if self.total_len == 0:
             raise pipeline.PipelineStopIteration
 
-        self.log.debug("Producing test data '{}'...".format(self.tag))
+        self.log.debug(f"Producing test data '{self.tag}'...")
 
         cont = memh5.BasicCont()
 

--- a/draco/util/tools.py
+++ b/draco/util/tools.py
@@ -4,12 +4,12 @@ Miscellaneous tasks should be placed in :py:mod:`draco.core.misc`.
 """
 
 import numpy as np
-from numpy.lib.recfunctions import structured_to_unstructured
-
-from ._fast_tools import _calc_redundancy
 
 # Keep this here for compatibility
 from caput.tools import invert_no_zero  # noqa: F401
+from numpy.lib.recfunctions import structured_to_unstructured
+
+from ._fast_tools import _calc_redundancy
 
 
 def cmap(i, j, n):
@@ -29,8 +29,8 @@ def cmap(i, j, n):
     """
     if i <= j:
         return (n * (n + 1) // 2) - ((n - i) * (n - i + 1) // 2) + (j - i)
-    else:
-        return cmap(j, i, n)
+
+    return cmap(j, i, n)
 
 
 def icmap(ix, n):
@@ -115,10 +115,10 @@ def find_keys(key_list, keys, require_match=False):
         dct = {kk: ii for ii, kk in enumerate(key_list)}
         index = [dct.get(key) for key in keys]
 
-    if require_match and any([ind is None for ind in index]):
+    if require_match and any(ind is None for ind in index):
         raise ValueError("Could not find all of the keys.")
-    else:
-        return index
+
+    return index
 
 
 def find_inputs(input_index, inputs, require_match=False):
@@ -220,11 +220,11 @@ def apply_gain(vis, gain, axis=1, out=None, prod_map=None):
         ii, ij = prod_map[pp]
 
         # Fetch the gains
-        gi = gain[gain_vis_slice + (ii,)]
-        gj = gain[gain_vis_slice + (ij,)].conj()
+        gi = gain[(*gain_vis_slice, ii)]
+        gj = gain[(*gain_vis_slice, ij)].conj()
 
         # Apply the gains and save into the output array.
-        out[gain_vis_slice + (pp,)] = vis[gain_vis_slice + (pp,)] * gi * gj
+        out[(*gain_vis_slice, pp)] = vis[(*gain_vis_slice, pp)] * gi * gj
 
     return out
 
@@ -264,10 +264,8 @@ def extract_diagonal(utmat, axis=1):
     slice1 = (np.s_[:],) * (len(utmat.shape) - axis - 1)
 
     # Extract wanted elements with a giant slice
-    sl = slice0 + (diag_ind,) + slice1
-    diag_array = utmat[sl]
-
-    return diag_array
+    sl = (*slice0, diag_ind, *slice1)
+    return utmat[sl]
 
 
 def calculate_redundancy(input_flags, prod_map, stack_index, nstack):
@@ -535,6 +533,4 @@ def window_generalised(x, window="nuttall"):
     t = 2 * np.pi * np.arange(4)[:, np.newaxis] * x[np.newaxis, :]
 
     w = (a[:, np.newaxis] * np.cos(t)).sum(axis=0)
-    w = np.where((x >= 0) & (x <= 1), w, 0)
-
-    return w
+    return np.where((x >= 0) & (x <= 1), w, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ exclude = [
     "*/__init__.py",
 ]
 
-target-version = "py311"
+target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ignore = [
     "D413", # D413: Missing blank line after last section
     "D416", # D416: Section name should end with a colon
     "NPY002", # NPY002: replace legacy numpy.random calls with np.random.Generator
+    "RUF012", # RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 
 # Ignore the following directories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,18 @@ addopts = "--strict-markers"
 markers = ["mpi: mark a test that should be run under MPI"]
 
 [tool.ruff]
-# Enable pycodestyle ('E'), pydocstyle ('D'), pyflakes ('F')
-select = ["E", "D", "F"]
+# Enable:
+# pycodestyle ('E')
+# pydocstyle ('D')
+# pyflakes ('F')
+# isort ('I')
+# pyupgrade ('UP')
+# numpy-specific ('NPY')
+# ruff-specific ('RUF')
+# flake8-blind-except ('BLE')
+# flake8-comprehensions ('C4')
+# flake8-return ('RET')
+select = ["E", "D", "F", "I", "UP", "NPY", "RUF", "BLE", "C4", "RET"]
 
 # E203, W503
 ignore = [
@@ -23,6 +33,7 @@ ignore = [
     "D402", # D402: First line should not be the function’s “signature”
     "D413", # D413: Missing blank line after last section
     "D416", # D416: Section name should end with a colon
+    "NPY002", # NPY002: replace legacy numpy.random calls with np.random.Generator
 ]
 
 # Ignore the following directories
@@ -34,6 +45,7 @@ exclude = [
     "test",
     "setup.py",
     "versioneer.py",
+    "*/_version.py",
     "*/__init__.py",
 ]
 


### PR DESCRIPTION
These additions are useful for improving overall quality and consistency of code and eliminating extra things for PR reviewers to check. The ruff python version is set to python 3.8, since this is the minimum supported version. 

- isort: formats and alphabetically orders imports
- pyupgrade: upgrade syntax for newer versions of python (based on the version specified in pyproject.toml)
- numpy: check deprecated types
- ruff-specific: ambiguous unicode, collection instead of concatenation
- flake8-blind-except: don't allow blind `except` statements
- flake8-comprehensions: use comprehensions instead of concatenation where possible
- flake8-return: consistent and clear return statements

Additional ignored rules:
- NPY002: replace legacy numpy.random calls with np.random.Generator

I'm happy to add more rules if there's anything else of interest