### PR TITLE
perf(sidereal): clear timestream list after concatenation

### DIFF
--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -148,6 +148,9 @@ class SiderealGrouper(task.SingleTask):
         ts.attrs["tag"] = "lsd_%i" % lsd
         ts.attrs["lsd"] = lsd
 
+        # Clear the timestream list since these days have already been processed
+        self._timestream_list = []
+
         return ts
 
 


### PR DESCRIPTION
This PR ensures that the timestream list is cleared whenever a concatenated product is made. If concatenation is done in `process_finish`, rather than the clause in `.process` (L101), all of the timestream files will be kept around until the next time the pipeline iterates through all tasks. In the case of the daily pipeline, this often doesn't happen until partway through the second stage, causing it to use significantly more memory than needed.