### PR TITLE
fix(ringmapmaker): fix bug finding shortest baseline in find_basis

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1125,7 +1125,7 @@ def find_basis(baselines):
         Unit vectors pointing in the mostly X and mostly Y directions of the grid.
     """
     # Find the shortest baseline, this should give one of the axes
-    bl = np.abs(baselines)
+    bl = np.sum(baselines**2, axis=1)
     bl[bl == 0] = 1e30
     ind = np.argmin(bl)
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2874,7 +2874,7 @@ def copy_datasets_filter(
         not be copied.
     """
     exclude_axes_set = set(exclude_axes) if exclude_axes else set()
-    if type(axis) is str:
+    if isinstance(axis, str):
         axis = [axis]
     axis = set(axis)
 

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -775,9 +775,9 @@ class Truncate(task.SingleTask):
 
         # Parse config parameters
         params = self.default_params.copy()
-        if type(given_params) is dict:
+        if isinstance(given_params, dict):
             params.update(given_params)
-        elif type(given_params) is float:
+        elif isinstance(given_params, float):
             params["fixed_precision"] = given_params
         elif not given_params:
             self.log.debug(f"Not truncating dataset '{dset}' in {container}.")


### PR DESCRIPTION
Previous version gives the correct result for CHIME, but can result in incorrect values for the grid spacing and indices for other telescopes due to a bug in how the shortest baseline is identified.