### PR TITLE
Redistribute back to frequency after generating baseline mask

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -933,6 +933,10 @@ class ThresholdVisWeightBaseline(task.SingleTask):
         # Save mask to output container
         mask_cont.mask[:] = mpiarray.MPIArray.wrap(local_mask, axis=1)
 
+        # Distribute back across frequency
+        mask_cont.redistribute("freq")
+        stream.redistribute("freq")
+
         return mask_cont
 
 


### PR DESCRIPTION
I'm not sure why this didn't pop up sooner, but at the moment this task will leave the sidereal stream in a non-ideal state, with the `weights` dataset distributed differently from the rest of the container. This just makes sure that both the mask and the sidereal stream are reverted to a standard distribution 