### PR TITLE
Delay cross power spectrum estimator

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -357,6 +357,11 @@ class DelayTransformBase(task.SingleTask):
         Whether to assume the original time samples that were channelized into a
         frequency spectrum were purely real (False) or complex (True). If True,
         `freq_zero`, `nfreq`, and `skip_nyquist` are ignored. Default: False.
+    weight_boost : float, optional
+        Multiply weights in the input container by this factor. This causes the task to
+        assume the noise power in the data is `weight_boost` times lower, which is
+        useful if you want the "true" noise to not be downweighted by the Wiener filter,
+        or have it included in the Gibbs sampler. Default: 1.0.
     """
 
     freq_zero = config.Property(proptype=float, default=None)
@@ -378,6 +383,7 @@ class DelayTransformBase(task.SingleTask):
         default="nuttall",
     )
     complex_timedomain = config.Property(proptype=bool, default=False)
+    weight_boost = config.Property(proptype=float, default=1.0)
 
     def process(self, ss):
         """Estimate the delay spectrum or power spectrum.
@@ -544,16 +550,10 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
     initial_amplitude : float, optional
         The Gibbs sampler will be initialized with a flat power spectrum with
         this amplitude. Default: 10.
-    weight_boost : float, optional
-         Multiply weights in the input container by this factor. This causes the Gibbs
-         sampler to assume the noise power in the data is `weight_boost` times lower,
-         which is useful if you want the "true" noise to be included in the power
-         spectrum measured by the Gibbs sampler. Default: 1.0.
     """
 
     nsamp = config.Property(proptype=int, default=20)
     initial_amplitude = config.Property(proptype=float, default=10.0)
-    weight_boost = config.Property(proptype=float, default=1.0)
     save_samples = config.Property(proptype=bool, default=False)
 
     def _create_output(
@@ -808,17 +808,7 @@ class DelaySpectrumWienerEstimator(DelayGeneralContainerBase):
     spectrum, assuming an input model for the delay power spectrum of the signal and
     that the noise power is described by the weights of the input container. See
     https://arxiv.org/abs/2202.01242, Eq. A6 for details.
-
-    Attributes
-    ----------
-    weight_boost : float, optional
-         Multiply weights in the input container by this factor. This causes the Wiener
-         filter to assume the noise power in the data is `weight_boost` times lower,
-         which is useful if you want the "true" noise to not be downweighted by the
-         Wiener filter. Default: 1.0.
     """
-
-    weight_boost = config.Property(proptype=float, default=1.0)
 
     def setup(self, dps: containers.DelaySpectrum):
         """Set the delay power spectrum to use as the signal covariance.

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -554,6 +554,7 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
     nsamp = config.Property(proptype=int, default=20)
     initial_amplitude = config.Property(proptype=float, default=10.0)
     weight_boost = config.Property(proptype=float, default=1.0)
+    save_samples = config.Property(proptype=bool, default=False)
 
     def _create_output(
         self,
@@ -580,6 +581,7 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
         delay_spec = containers.DelaySpectrum(
             baseline=bl,
             delay=delays,
+            sample=self.nsamp,
             attrs_from=ss,
         )
 
@@ -593,6 +595,9 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
             for ax in coord_axes:
                 delay_spec.create_index_map(ax, ss.index_map[ax])
             delay_spec.attrs["baseline_axes"] = coord_axes
+
+        if self.save_samples:
+            delay_spec.add_dataset("spectrum_samples")
 
         return delay_spec
 
@@ -675,6 +680,9 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
             # (presuming that removes the burn-in)
             spec_av = np.median(spec[-(self.nsamp // 2) :], axis=0)
             out_cont.spectrum[bi] = np.fft.fftshift(spec_av)
+
+            if self.save_samples:
+                out_cont.datasets["spectrum_samples"][:, bi] = spec
 
         return out_cont
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2428,7 +2428,14 @@ class DelayCrossSpectrum(DelaySpectrum):
             "initialise": True,
             "distributed": True,
             "distributed_axis": "baseline",
-        }
+        },
+        "spectrum_samples": {
+            "axes": ["sample", "dataset", "dataset", "baseline", "delay"],
+            "dtype": np.float64,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        },
     }
 
     @property

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2273,7 +2273,18 @@ class DelayCutoff(ContainerBase):
         return self.index_map["el"]
 
 
-class DelaySpectrum(ContainerBase):
+class DelayContainer(ContainerBase):
+    """A container with a delay axis."""
+
+    _axes = ("delay",)
+
+    @property
+    def delay(self) -> np.ndarray:
+        """The delay axis in microseconds."""
+        return self.index_map["delay"]
+
+
+class DelaySpectrum(DelayContainer):
     """Container for a delay power spectrum.
 
     Notes
@@ -2287,7 +2298,7 @@ class DelaySpectrum(ContainerBase):
     container.
     """
 
-    _axes = ("baseline", "delay")
+    _axes = ("baseline",)
 
     _dataset_spec = {
         "spectrum": {
@@ -2323,7 +2334,7 @@ class DelaySpectrum(ContainerBase):
         return self.attrs["freq"]
 
 
-class DelayTransform(ContainerBase):
+class DelayTransform(DelayContainer):
     """Container for a delay spectrum.
 
     Notes
@@ -2332,7 +2343,7 @@ class DelayTransform(ContainerBase):
     description of the difference between `DelayTransform` and `DelaySpectrum`.
     """
 
-    _axes = ("baseline", "sample", "delay")
+    _axes = ("baseline", "sample")
 
     _dataset_spec = {
         "spectrum": {
@@ -2368,10 +2379,10 @@ class DelayTransform(ContainerBase):
         return self.attrs["freq"]
 
 
-class WaveletSpectrum(FreqContainer, DataWeightContainer):
+class WaveletSpectrum(FreqContainer, DelayContainer, DataWeightContainer):
     """Container for a wavelet power spectrum."""
 
-    _axes = ("baseline", "freq", "delay")
+    _axes = ("baseline",)
 
     _dataset_spec = {
         "spectrum": {

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2075,7 +2075,34 @@ class RingMapMask(FreqContainer, SiderealContainer):
         return self.datasets["mask"]
 
 
-class CommonModeGainData(FreqContainer, TODContainer):
+class GainDataBase(DataWeightContainer):
+    """A container interface for gain-like data.
+
+    To support the previous behaviour of gain type data the weight dataset is optional,
+    and returns None if it is not present.
+    """
+
+    _data_dset_name = "gain"
+    _weight_dset_name = "weight"
+
+    @property
+    def gain(self) -> memh5.MemDataset:
+        """Get the gain dataset."""
+        return self.datasets["gain"]
+
+    @property
+    def weight(self) -> Optional[memh5.MemDataset]:
+        """The weights for each data point.
+
+        Returns None is no weight dataset exists.
+        """
+        try:
+            return super().weight
+        except KeyError:
+            return None
+
+
+class CommonModeGainData(FreqContainer, TODContainer, GainDataBase):
     """Parallel container for holding gain data common to all inputs."""
 
     _dataset_spec = {
@@ -2095,21 +2122,8 @@ class CommonModeGainData(FreqContainer, TODContainer):
         },
     }
 
-    @property
-    def gain(self):
-        """Get the gain dataset."""
-        return self.datasets["gain"]
 
-    @property
-    def weight(self):
-        """Get the weight dataset if it exists."""
-        try:
-            return self.datasets["weight"]
-        except KeyError:
-            return None
-
-
-class CommonModeSiderealGainData(FreqContainer, SiderealContainer):
+class CommonModeSiderealGainData(FreqContainer, SiderealContainer, GainDataBase):
     """Parallel container for holding sidereal gain data common to all inputs."""
 
     _dataset_spec = {
@@ -2129,21 +2143,8 @@ class CommonModeSiderealGainData(FreqContainer, SiderealContainer):
         },
     }
 
-    @property
-    def gain(self):
-        """Get the gain dataset."""
-        return self.datasets["gain"]
 
-    @property
-    def weight(self):
-        """Get the weight dataset if it exists."""
-        try:
-            return self.datasets["weight"]
-        except KeyError:
-            return None
-
-
-class GainData(FreqContainer, TODContainer):
+class GainData(FreqContainer, TODContainer, GainDataBase):
     """Parallel container for holding gain data."""
 
     _axes = ("input",)
@@ -2172,19 +2173,6 @@ class GainData(FreqContainer, TODContainer):
     }
 
     @property
-    def gain(self):
-        """Get the gain dataset."""
-        return self.datasets["gain"]
-
-    @property
-    def weight(self):
-        """Get the weight dataset if it exists."""
-        try:
-            return self.datasets["weight"]
-        except KeyError:
-            return None
-
-    @property
     def update_id(self):
         """Get the update id dataset if it exists."""
         try:
@@ -2198,7 +2186,7 @@ class GainData(FreqContainer, TODContainer):
         return self.index_map["input"]
 
 
-class SiderealGainData(FreqContainer, SiderealContainer):
+class SiderealGainData(FreqContainer, SiderealContainer, GainDataBase):
     """Parallel container for holding sidereal gain data."""
 
     _axes = ("input",)
@@ -2221,25 +2209,12 @@ class SiderealGainData(FreqContainer, SiderealContainer):
     }
 
     @property
-    def gain(self):
-        """Get the gain dataset."""
-        return self.datasets["gain"]
-
-    @property
-    def weight(self):
-        """Get the weight dataset if it exists."""
-        try:
-            return self.datasets["weight"]
-        except KeyError:
-            return None
-
-    @property
     def input(self):
         """Get the input axis."""
         return self.index_map["input"]
 
 
-class StaticGainData(FreqContainer, DataWeightContainer):
+class StaticGainData(FreqContainer, GainDataBase):
     """Parallel container for holding static gain data (i.e. non time varying)."""
 
     _axes = ("input",)
@@ -2260,14 +2235,6 @@ class StaticGainData(FreqContainer, DataWeightContainer):
             "distributed_axis": "freq",
         },
     }
-
-    _data_dset_name = "gain"
-    _weight_dset_name = "weight"
-
-    @property
-    def gain(self):
-        """Get the gain dataset."""
-        return self.datasets["gain"]
 
     @property
     def input(self):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2298,7 +2298,7 @@ class DelaySpectrum(DelayContainer):
     container.
     """
 
-    _axes = ("baseline",)
+    _axes = ("baseline", "sample")
 
     _dataset_spec = {
         "spectrum": {
@@ -2307,11 +2307,18 @@ class DelaySpectrum(DelayContainer):
             "initialise": True,
             "distributed": True,
             "distributed_axis": "baseline",
-        }
+        },
+        "spectrum_samples": {
+            "axes": ["sample", "baseline", "delay"],
+            "dtype": np.float64,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "baseline",
+        },
     }
 
-    def __init__(self, weight_boost=1.0, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, weight_boost=1.0, sample=1, **kwargs):
+        super().__init__(*args, sample=sample, **kwargs)
         self.attrs["weight_boost"] = weight_boost
 
     @property


### PR DESCRIPTION
Here is a finalised version of the cross spectrum estimator that fits in with Simon's earlier refactoring. To make it work I've had to refactor the base code a bit further to remove some duplication. Notable changes:
- The output container creation has been moved from `_process_data` into a new `_create_output` method.
- The delay calculation code is moved into its own method `_calculate_delays`
- The data/weight manipulation code is moved into `_cut_data` method.

With these changes above it's reasonably simple to create a new cross spectrum estimator task.

Also in this PR I've merged in some changes I made to work with the absorber project of a mixin to abstract over containers with a "data" dataset and a corresponding weight dataset. That allows the general container transforms to chose the right datasets to use without explicitly specifying them.