### PR TITLE
feat(flagging): mask rfi based on delay filtered visibilities

### DIFF
--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -189,6 +189,144 @@ class DayenuDelayFilter(task.SingleTask):
         return baseline_delay_cut + self.tauw
 
 
+class DayenuDelayFilterFixedCutoff(task.SingleTask):
+    """Apply a DAYENU high-pass delay filter to visibility data.
+
+    This task loops over time instead of baseline.  It can be used
+    to filter timeseries that have a rapidly changing frequency mask,
+    with the caveat that one must use the same delay cutoff for all baselines.
+
+    Attributes
+    ----------
+    epsilon : float
+        The stop-band rejection of the filter.  Default is 1e-12.
+    tauw : float
+        Delay cutoff in micro-seconds.  Default is 0.4 micro-seconds.
+    single_mask : bool
+        Apply a single frequency mask for all baselines.  Only includes
+        frequencies where the weights are nonzero for all baselines.
+        Otherwise will construct a filter for all unique single-time
+        frequency masks (can be significantly slower).  Default is True.
+    atten_threshold : float
+        Mask any frequency where the diagonal element of the filter
+        is less than this fraction of the median value over all
+        unmasked frequencies.  Default is 0.0 (i.e., do not mask
+        frequencies with low attenuation).
+    """
+
+    epsilon = config.Property(proptype=float, default=1e-12)
+    tauw = config.Property(proptype=float, default=0.400)
+    single_mask = config.Property(proptype=bool, default=True)
+    atten_threshold = config.Property(proptype=float, default=0.0)
+
+    def process(self, stream):
+        """Filter delays below some cutoff.
+
+        Modifies container in place.
+
+        Parameters
+        ----------
+        stream : TimeStream or SiderealStream
+
+        Returns
+        -------
+        stream_filt : TimeStream or SiderealStream
+        """
+        # Distribute over products
+        stream.redistribute(["ra", "time"])
+
+        # Extract the required axes
+        freq = stream.freq[:]
+
+        ntime = stream.vis.local_shape[2]
+
+        # Dereference the required datasets
+        vis = stream.vis[:].local_array
+        weight = stream.weight[:].local_array
+
+        # Identify baselines that are always flagged
+        temp = np.any(weight > 0.0, axis=(0, 2))
+        baseline_flag = np.zeros_like(temp)
+        self.comm.Allreduce(temp, baseline_flag, op=MPI.LOR)
+        baseline_mask = ~baseline_flag
+
+        if np.all(baseline_mask):
+            self.log.error("All data flaged as bad.")
+            return
+        elif np.any(baseline_mask) and not self.single_mask:
+            valid = np.flatnonzero(baseline_flag)
+        else:
+            valid = slice(None)
+
+        # Loop over products
+        for tt in range(ntime):
+
+            t0 = time.time()
+
+            # Flag frequencies and times with zero weight
+            if self.single_mask:
+                flag = (weight[:, :, tt] > 0.0) | baseline_mask
+                flag = np.all(flag, axis=-1, keepdims=True)
+                weight[:, :, tt] *= flag.astype(weight.dtype)
+            else:
+                flag = weight[:, valid, tt] > 0.0
+
+            if not np.any(flag):
+                continue
+
+            tvis = np.ascontiguousarray(vis[:, valid, tt])
+            tvar = tools.invert_no_zero(weight[:, valid, tt])
+
+            self.log.debug(f"Filter time {tt} of {ntime}. [{self.tauw:0.3f} microsec]")
+
+            # Construct the filter
+            try:
+                NF, index = highpass_delay_filter(
+                    freq, self.tauw, flag, epsilon=self.epsilon
+                )
+
+            except np.linalg.LinAlgError as exc:
+                self.log.error("Failed to converge while processing time {tt}: {exc}")
+                weight[:, :, tt] = 0.0
+                continue
+
+            # Apply the filter
+            if self.single_mask:
+                vis[:, :, tt] = np.matmul(NF[0], tvis)
+                weight[:, :, tt] = tools.invert_no_zero(np.matmul(NF[0] ** 2, tvar))
+
+                if self.atten_threshold > 0.0:
+                    diag = np.diag(NF[0])
+                    med_diag = np.median(diag[diag > 0.0])
+
+                    flag_low = diag > (self.atten_threshold * med_diag)
+
+                    weight[:, :, tt] *= flag_low[:, np.newaxis].astype(weight.dtype)
+
+            else:
+                self.log.debug(f"There are {len(index)} unique masks/filters.")
+                for ii, ind in enumerate(index):
+
+                    vis[:, valid[ind], tt] = np.matmul(NF[ii], tvis[:, ind])
+                    weight[:, valid[ind], tt] = tools.invert_no_zero(
+                        np.matmul(NF[ii] ** 2, tvar[:, ind])
+                    )
+
+                    if self.atten_threshold > 0.0:
+                        diag = np.diag(NF[ii])
+                        med_diag = np.median(diag[diag > 0.0])
+
+                        flag_low = diag > (self.atten_threshold * med_diag)
+
+                        weight[:, valid[ind], tt] *= flag_low[:, np.newaxis].astype(
+                            weight.dtype
+                        )
+
+            self.log.debug(f"Took {time.time() - t0:0.3f} seconds in total.")
+
+        return stream
+
+
 class DayenuDelayFilterMap(task.SingleTask):
     """Apply a DAYENU high-pass delay filter to ringmap data.
 

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -130,9 +130,12 @@ class DayenuDelayFilter(task.SingleTask):
                 )
 
             except np.linalg.LinAlgError as exc:
+                pc_good = (100.0 * flag.mean(axis=0)).astype(int)
                 self.log.error(
-                    "Failed to converge while processing baseline "
-                    f"{bb} [{bcut:0.3f} micro-sec]: {exc}"
+                    f"Failed to converge while processing baseline {bb} "
+                    f"[{bcut:0.3f} micro-sec]\n"
+                    f"Percentage unmasked frequencies:  {pc_good}\n"
+                    f"Exception:  {exc}"
                 )
                 weight[:, bb] = 0.0
                 continue
@@ -252,7 +255,7 @@ class DayenuDelayFilterFixedCutoff(task.SingleTask):
         baseline_mask = ~baseline_flag
 
         if np.all(baseline_mask):
-            self.log.error("All data flaged as bad.")
+            self.log.error("All data flagged as bad.")
             return None
 
         if np.any(baseline_mask) and not self.single_mask:
@@ -288,7 +291,12 @@ class DayenuDelayFilterFixedCutoff(task.SingleTask):
                 )
 
             except np.linalg.LinAlgError as exc:
-                self.log.error(f"Failed to converge while processing time {tt}: {exc}")
+                pc_good = (100.0 * flag.mean(axis=0)).astype(int)
+                self.log.error(
+                    f"Failed to converge while processing time {tt}.\n"
+                    f"Percentage unmasked frequencies:  {pc_good}\n"
+                    f"Exception:  {exc}"
+                )
                 weight[:, :, tt] = 0.0
                 continue
 
@@ -472,9 +480,12 @@ class DayenuDelayFilterMap(task.SingleTask):
                     )
 
                 except np.linalg.LinAlgError as exc:
+                    pc_good = (100.0 * flag.mean(axis=0)).astype(int)
                     self.log.error(
-                        "Failed to converge while processing el "
-                        f"{el:0.3f} [{ecut:0.3f} micro-sec]: {exc}"
+                        f"Failed to converge while processing el {el:0.3f} "
+                        f"[{ecut:0.3f} micro-sec]\n"
+                        f"Percentage unmasked frequencies:  {pc_good}\n"
+                        f"Exception:  {exc}"
                     )
                     weight[wslc] = 0.0
                     continue

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -208,7 +208,7 @@ class DayenuDelayFilterFixedCutoff(transform.ReduceChisq):
     epsilon : float
         The stop-band rejection of the filter.  Default is 1e-12.
     tauw : float
-        Delay cutoff in micro-seconds.  Default is 0.4 micro-seconds.
+        Delay cutoff in micro-seconds.  Default is 0.45 micro-seconds.
     single_mask : bool
         Apply a single frequency mask for all baselines.  Only includes
         frequencies where the weights are nonzero for all baselines.
@@ -227,7 +227,7 @@ class DayenuDelayFilterFixedCutoff(transform.ReduceChisq):
     """
 
     epsilon = config.Property(proptype=float, default=1e-12)
-    tauw = config.Property(proptype=float, default=0.400)
+    tauw = config.Property(proptype=float, default=0.450)
     single_mask = config.Property(proptype=bool, default=True)
     atten_threshold = config.Property(proptype=float, default=0.0)
 

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -7,6 +7,8 @@ import time
 
 import numpy as np
 import scipy.interpolate
+from mpi4py import MPI
+
 from caput import config
 from cora.util import units
 
@@ -227,10 +229,12 @@ class DayenuDelayFilterFixedCutoff(task.SingleTask):
         Parameters
         ----------
         stream : TimeStream or SiderealStream
+            Raw visibilities.
 
         Returns
         -------
         stream_filt : TimeStream or SiderealStream
+            Filtered visibilities.
         """
         # Distribute over products
         stream.redistribute(["ra", "time"])
@@ -252,8 +256,9 @@ class DayenuDelayFilterFixedCutoff(task.SingleTask):
 
         if np.all(baseline_mask):
             self.log.error("All data flaged as bad.")
-            return
-        elif np.any(baseline_mask) and not self.single_mask:
+            return None
+
+        if np.any(baseline_mask) and not self.single_mask:
             valid = np.flatnonzero(baseline_flag)
         else:
             valid = slice(None)

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -7,10 +7,9 @@ import time
 
 import numpy as np
 import scipy.interpolate
-from mpi4py import MPI
-
 from caput import config
 from cora.util import units
+from mpi4py import MPI
 
 from ..core import containers, io, task
 from ..util import tools
@@ -122,9 +121,7 @@ class DayenuDelayFilter(task.SingleTask):
             bvis = np.ascontiguousarray(vis[:, bb])
             bvar = tools.invert_no_zero(weight[:, bb])
 
-            self.log.debug(
-                "Filtering baseline %d of %d. [%0.3f micro-sec]" % (bb, nprod, bcut)
-            )
+            self.log.debug(f"Filter baseline {bb} of {nprod}. [{bcut:0.3f} micro-sec]")
 
             # Construct the filter
             try:
@@ -291,7 +288,7 @@ class DayenuDelayFilterFixedCutoff(task.SingleTask):
                 )
 
             except np.linalg.LinAlgError as exc:
-                self.log.error("Failed to converge while processing time {tt}: {exc}")
+                self.log.error(f"Failed to converge while processing time {tt}: {exc}")
                 weight[:, :, tt] = 0.0
                 continue
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1173,7 +1173,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         baseline = tools.arPLS_1d(med_y, mask=med_m, lam=self.reg_arpls)
 
         # Subtract the baseline and estimate the noise
-        abs_dev = np.abs(med_y - baseline)
+        abs_dev = np.where(med_m, 0.0, np.abs(med_y - baseline))
 
         mad = 1.48625 * weighted_median.weighted_median(abs_dev, med_w)
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1022,7 +1022,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         of freedom (i.e., number of baselines).
     """
 
-    reg_arpls = config.Property(proptype=float, default=100000.0)
+    reg_arpls = config.Property(proptype=float, default=1e5)
     nsigma_1d = config.Property(proptype=float, default=5.0)
 
     win_t = config.Property(proptype=int, default=601)
@@ -1170,7 +1170,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         med_w = np.ascontiguousarray((~med_m).astype(np.float64))
 
         # Estimate a baseline
-        baseline = tools.arPLS_1d(med_y, mask=med_m, scale=self.reg_arpls)
+        baseline = tools.arPLS_1d(med_y, mask=med_m, lam=self.reg_arpls)
 
         # Subtract the baseline and estimate the noise
         abs_dev = np.abs(med_y - baseline)

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -997,6 +997,257 @@ class CollapseBaselineMask(task.SingleTask):
         return mask_cont
 
 
+class RFIMaskChisqHighDelay(task.SingleTask):
+    """Mask frequencies and times with anomalous chi-squared test statistic.
+
+    Attributes
+    ----------
+    reg_arpls : float
+        Smoothness regularisation used when estimating the baseline
+        for flagging bad frequencies. Default is 1e5.
+    nsigma_1d : float
+        Mask any frequency where the median over unmasked time samples
+        deviates from the baseline by more than this number of
+        median absolute deviations.  Default is 5.0.
+    win_t : float
+        Size of the window (in number of time samples)
+        used to compute a median filtered version of the test statistic.
+    win_f : float
+        Size of the window (in number of frequency channels)
+        used to compute a median filtered version of the test statistic.
+    nsigma_2d: float
+        Mask any frequency and time where the absolute deviation
+        from the median filtered version is greater than this number
+        of expected standard deviations given the number of degrees
+        of freedom (i.e., number of baselines).
+    """
+
+    reg_arpls = config.Property(proptype=float, default=100000.0)
+    nsigma_1d = config.Property(proptype=float, default=5.0)
+
+    win_t = config.Property(proptype=int, default=601)
+    win_f = config.Property(proptype=int, default=1)
+    nsigma_2d = config.Property(proptype=float, default=5.0)
+
+    def setup(self, telescope=None):
+        """Save telescope object for time calculations.
+
+        Only used to convert (LSD, RA) to unix time when masking
+        sidereal streams.  Not required when masking time streams.
+
+        Parameters
+        ----------
+        telescope : TransitTelescope
+        """
+        self.telescope = None if telescope is None else io.get_telescope(telescope)
+
+    def process(self, stream):
+        """Generate a mask from the data.
+
+        Parameters
+        ----------
+        stream : dcontainers.TimeStream | dcontainers.SiderealStream
+            Container holding a chi-squared test statistic in the visibility dataset.
+            A weighted average will be taken over any axis that is not time/ra or frequency.
+
+        Returns
+        -------
+        mask : dcontainers.RFIMask | dcontainers.SiderealRFIMask
+            Time-frequency mask, where values marked `True` are flagged.
+        """
+
+        # Distribute over frequency
+        stream.redistribute("freq")
+        freq = stream.freq
+
+        # Determine time axis
+        multiple_days = False
+        if "ra" in stream.index_map:
+
+            if self.telescope is None:
+                raise RuntimeError(
+                    "For sidereal streams, must provide "
+                    "telescope object during setup."
+                )
+
+            csd = stream.attrs.get("lsd", stream.attrs.get("csd"))
+            if csd is None:
+                raise ValueError("Data does not have a `csd` or `lsd` attribute.")
+
+            if not np.isscalar(csd):
+                csd = np.floor(np.mean(csd))
+                multiple_days = True
+
+            timestamp = self.telescope.lsd_to_unix(csd + stream.ra / 360.0)
+
+        else:
+            timestamp = stream.time
+
+        # Sum over any axis that is neither time nor frequency
+        axsum = tuple(
+            [
+                ii
+                for ii, ax in enumerate(stream.vis.attrs["axis"])
+                if ax not in ["freq", "time", "ra"]
+            ]
+        )
+
+        chisq = stream.vis[:].real
+        weight = stream.weight[:]
+
+        wsum = np.sum(weight, axis=axsum)
+        chisq = np.sum(weight * chisq, axis=axsum) * tools.invert_no_zero(wsum)
+
+        # Gather all frequencies on all nodes
+        chisq = chisq.allgather()
+        wsum = wsum.allgather()
+
+        mask_input = wsum == 0.0
+
+        # Determine what time samples should be ignored when constructing the mask
+        if multiple_days:
+            mask_daytime = np.zeros(timestamp.size, dtype=bool)
+        else:
+            mask_daytime = self._day_flag_hook(timestamp)
+
+        mask_time = self._source_flag_hook(timestamp, freq)
+
+        mask = mask_input | mask_time
+
+        # Mask using median over time
+        mask_output = np.zeros((freq.size, timestamp.size), dtype=bool)
+
+        if self.nsigma_1d > 0.0:
+            mask_1d = self.mask_1d(chisq, mask | mask_daytime)[:, np.newaxis]
+            mask |= mask_1d
+            mask_output |= mask_1d
+
+        # Mask using dynamic spectrum
+        if self.nsigma_2d > 0.0:
+            # The inverse variance of the chisq per dof test statistic is ndof / 2.
+            # This expression assumes ndof is stored in the weight dataset.
+            w = ~mask * wsum / 2.0
+            mask_2d = self.mask_2d(chisq, w)
+
+            mask_output |= mask_2d & ~mask_daytime
+
+        # Save to output container
+        OutputContainer = (
+            containers.SiderealRFIMask
+            if "ra" in stream.index_map
+            else containers.RFIMask
+        )
+        output = OutputContainer(axes_from=stream, attrs_from=stream)
+
+        output.mask[:] = mask_output
+
+        return output
+
+    def mask_1d(self, y, m):
+        """Mask frequency channels where median chi-squared deviates from neighbors.
+
+        Parameters
+        ----------
+        y : np.ndarray[nfreq, ntime]
+            Chi-squared per degree of freedom.
+        m : np.ndarray[nfreq, ntime]
+            Boolean mask that indicates which samples to ignore
+            when calculating the median over time.
+
+        Returns
+        -------
+        mask : np.ndarray[nfreq]
+            Boolean mask that indicates frequency channels where
+            the median chi-squared over time deviates significantly
+            from that of the neighboring channels.
+        """
+        # For each frequency, caculate a weighted median
+        y = np.ascontiguousarray(y.astype(np.float64))
+        w = np.ascontiguousarray((~m).astype(np.float64))
+
+        med_y = weighted_median.weighted_median(y, w)
+        med_m = np.all(m, axis=-1)
+        med_w = np.ascontiguousarray((~med_m).astype(np.float64))
+
+        # Estimate a baseline
+        baseline = tools.arPLS_1d(med_y, mask=med_m, scale=self.reg_arpls)
+
+        # Subtract the baseline and estimate the noise
+        abs_dev = np.abs(med_y - baseline)
+
+        mad = 1.48625 * weighted_median.weighted_median(abs_dev, med_w)
+
+        # Flag outliers
+        mask = abs_dev > self.nsigma_1d
+
+        return mask
+
+    def mask_2d(self, y, w):
+        """Mask frequencies and times where the chi-squared deviates from local median.
+
+        Parameters
+        ----------
+        y : np.ndarray[nfreq, ntime]
+            Chi-squared per degree of freedom.
+        w : np.ndarray[nfreq, ntime]
+            Inverse variance of the chi-squared per degree of freedom,
+            with zero indicating previously masked samples.
+
+        Returns
+        -------
+        mask : np.ndarray[nfreq]
+            Boolean mask that indicates frequencies and times where
+            chi-squared deviates significantly from the local median.
+        """
+        # For each frequency, caculate a moving weighted median
+        y = np.ascontiguousarray(y.astype(np.float64))
+        w = np.ascontiguousarray(w.astype(np.float64))
+        win_size = (self.win_f, self.win_t)
+
+        med_y = weighted_median.moving_weighted_median(y, w, win_size)
+
+        # Calculate the deviation from the median, normalized by the
+        # expected standard deviation
+        dy = np.abs(y - med_y) * np.sqrt(w)
+
+        # Flag times and frequencies that deviate by more than some threshold
+        mask = dy > self.nsigma_2d
+
+        return mask
+
+    def _source_flag_hook(self, times, freq):
+        """Override to mask bright point sources.
+
+        Parameters
+        ----------
+        times : np.ndarray[ntime]
+            Array of timestamps.
+        freq : np.ndarray[nfreq]
+            Array of frequencies.
+
+        Returns
+        -------
+        mask : np.ndarray[nfreq, ntime]
+            Mask array. True will mask out a time sample.
+        """
+        return np.zeros((freq.size, times.size), dtype=bool)
+
+    def _day_flag_hook(self, times):
+        """Override to mask daytime.
+
+        Parameters
+        ----------
+        times : np.ndarray[ntime]
+            Array of timestamps.
+
+        Returns
+        -------
+        mask : np.ndarray[nfreq, ntime]
+            Mask array. True will mask out a time sample.
+        """
+        return np.zeros(times.size, dtype=bool)
+
+
 class RFISensitivityMask(task.SingleTask):
     """Slightly less crappy RFI masking.
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1038,6 +1038,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         Parameters
         ----------
         telescope : TransitTelescope
+            Telescope object used for time calculations.
         """
         self.telescope = None if telescope is None else io.get_telescope(telescope)
 
@@ -1055,7 +1056,6 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         mask : dcontainers.RFIMask | dcontainers.SiderealRFIMask
             Time-frequency mask, where values marked `True` are flagged.
         """
-
         # Distribute over frequency
         stream.redistribute("freq")
         freq = stream.freq
@@ -1178,9 +1178,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         mad = 1.48625 * weighted_median.weighted_median(abs_dev, med_w)
 
         # Flag outliers
-        mask = abs_dev > self.nsigma_1d
-
-        return mask
+        return abs_dev > (self.nsigma_1d * mad)
 
     def mask_2d(self, y, w):
         """Mask frequencies and times where the chi-squared deviates from local median.
@@ -1211,9 +1209,7 @@ class RFIMaskChisqHighDelay(task.SingleTask):
         dy = np.abs(y - med_y) * np.sqrt(w)
 
         # Flag times and frequencies that deviate by more than some threshold
-        mask = dy > self.nsigma_2d
-
-        return mask
+        return dy > self.nsigma_2d
 
     def _source_flag_hook(self, times, freq):
         """Override to mask bright point sources.

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1466,13 +1466,43 @@ class ReduceVar(ReduceBase):
 
         # Calculate the inverted sum of the weights. This is used
         # more than once
-        ws = invert_no_zero(np.sum(weight, axis=axis, keepdims=True))
+        ws = np.sum(weight, axis=axis, keepdims=True)
+        iws = invert_no_zero(ws)
         # Get the weighted mean
-        mu = np.sum(weight * arr, axis=axis, keepdims=True) * ws
+        mu = np.sum(weight * arr, axis=axis, keepdims=True) * iws
         # Get the weighted variance
-        v = np.sum(weight * (arr - mu) ** 2, axis=axis, keepdims=True) * ws
+        v = np.sum(weight * (arr - mu) ** 2, axis=axis, keepdims=True) * iws
 
-        return v, np.ones_like(v)
+        return v, ws
+
+
+class ReduceChisq(ReduceBase):
+    """Calculate the chi-squared per degree of freedom.
+
+    Assumes that the visibilities are uncorrelated noise
+    whose inverse variance is given by the weight dataset.
+    """
+
+    _op = "chisq_per_dof"
+
+    def reduction(self, arr, weight, axis):
+        """Apply a chi-squared calculation."""
+
+        # Get the total number of unmasked samples
+        num = np.maximum(np.sum(weight > 0, axis=axis, keepdims=True) - 1, 0)
+
+        # Calculate the inverted sum of the weights
+        iws = invert_no_zero(np.sum(weight, axis=axis, keepdims=True))
+
+        # Get the weighted mean
+        mu = np.sum(weight * arr, axis=axis, keepdims=True) * iws
+
+        # Get the chi-squared per degree of freedom
+        v = np.sum(
+            weight * np.abs(arr - mu) ** 2, axis=axis, keepdims=True
+        ) * invert_no_zero(num)
+
+        return v, num
 
 
 class HPFTimeStream(task.SingleTask):

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1487,7 +1487,6 @@ class ReduceChisq(ReduceBase):
 
     def reduction(self, arr, weight, axis):
         """Apply a chi-squared calculation."""
-
         # Get the total number of unmasked samples
         num = np.maximum(np.sum(weight > 0, axis=axis, keepdims=True) - 1, 0)
 


### PR DESCRIPTION
Adds three new tasks:
 - analysis.dayenu.DayenuDelayFilterFixedCutoff enables delay filtering of timeseries with rapidly changing frequency masks.
 - analysis.transform.ReduceChisq calculates a chi2-per-dof test statistic by comparing the delay filtered visibilities to the inverse noise variance stored in the weights.
 - analysis.flagging.RFIMaskChisqHighDelay generates a mask from this chi2-per-dof test statistic.