### PR TITLE
Baseline-dependent rebinner

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -2298,10 +2298,16 @@ class BlendStack(task.SingleTask):
             The modified data. This is the same object as the input, and it has been
             modified in place.
         """
-        if type(self.data_stack) != type(data):
+        if "effective_ra" in data.datasets:
+            raise TypeError(
+                "Blending uncorrected rebinned data not supported. "
+                "Please apply a correction such as `sidereal.RebinGradientCorrection."
+            )
+
+        if not isinstance(data, type(self.data_stack)):
             raise TypeError(
                 f"type(data) (={type(data)}) must match"
-                f"type(data_stack) (={type(self.type)}"
+                f"type(data_stack) (={type(self.data_stack)}"
             )
 
         # Try and get both the stack and the incoming data to have the same

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1239,6 +1239,17 @@ class SiderealStream(
             "compression_opts": COMPRESSION_OPTS,
             "chunks": (64, 128, 128),
         },
+        "effective_ra": {
+            "axes": ["freq", "stack", "ra"],
+            "dtype": np.float32,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "freq",
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+            "chunks": (64, 128, 128),
+            "truncate": True,
+        },
     }
 
     @property
@@ -1255,6 +1266,14 @@ class SiderealStream(
     def _mean(self):
         """Get the vis dataset."""
         return self.datasets["vis"]
+
+    @property
+    def effective_ra(self):
+        """Get the effective_ra dataset if it exists, None otherwise."""
+        if "effective_ra" in self.datasets:
+            return self.datasets["effective_ra"]
+
+        raise KeyError("Dataset 'effective_ra' not initialised.")
 
 
 class SystemSensitivity(FreqContainer, TODContainer):

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -806,6 +806,11 @@ class VisContainer(VisBase):
         # Call initializer from `ContainerBase`
         super().__init__(*args, **kwargs)
 
+        # `axes_from` can be provided via the `copy_from` argument, so
+        # need to update kwargs to account
+        if ("axes_from" not in kwargs) and ("copy_from" in kwargs):
+            kwargs["axes_from"] = kwargs.pop("copy_from")
+
         reverse_map_stack = None
         # Create reverse map
         if "reverse_map_stack" in kwargs:

--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -4,8 +4,11 @@ This is described in some detail in `doclib:173
 <http://bao.chimenet.ca/doc/cgi-bin/general/documents/display?Id=173>`_.
 """
 
+from typing import List, Union
+
 import numpy as np
 import scipy.linalg as la
+import scipy.sparse as ss
 
 from ..util import _fast_tools
 
@@ -155,3 +158,137 @@ def lanczos_inverse_matrix(x, y, a=5, cond=1e-1):
     """
     lz_forward = lanczos_forward_matrix(x, y, a)
     return la.pinv(lz_forward, rcond=cond)
+
+
+def rebin_matrix(tra: np.ndarray, ra: np.ndarray, width_t: float = 0) -> np.ndarray:
+    """Construct a matrix to rebin the samples.
+
+    Parameters
+    ----------
+    tra
+        The samples we have in the time stream.
+    ra
+        The target samples we want in the sidereal stream.
+    width_t
+        The width of a time sample. Set to zero to do a nearest bin assignment.
+
+    Returns
+    -------
+    R
+        A matrix to perform the rebinning.
+    """
+    R = np.zeros((ra.shape[0], tra.shape[0]))
+
+    inds = np.searchsorted(ra, tra)
+
+    # Estimate the typical width of an RA bin
+    width_ra = np.median(np.abs(np.diff(ra)))
+
+    lowest_ra = ra[0] - width_ra / 2
+    highest_ra = ra[-1] + width_ra / 2
+
+    # NOTE: this is a bit of a hack to avoid zero division by zeros, but should have
+    # the required effect of giving 1 if the time sample is inside a bin, and zero
+    # otherwise.
+    if width_t == 0:
+        width_t = 1e-10
+
+    # NOTE: this can probably be done more efficiently, but we typically only need
+    # to do this once per day
+    for ii, (jj, t) in enumerate(zip(inds, tra)):
+
+        lower_edge = t - width_t / 2.0
+        upper_edge = t + width_t / 2.0
+
+        # If we are in here we have weight to assign to the sample below
+        if upper_edge > lowest_ra and jj < len(ra):
+            ra_edge = ra[jj] - width_ra / 2
+            wh = np.clip((upper_edge - ra_edge) / width_t, 0.0, 1.0)
+            R[jj, ii] = wh
+
+        if lower_edge < highest_ra and jj > 0:
+            ra_edge = ra[jj - 1] + width_ra / 2
+            wl = np.clip((ra_edge - lower_edge) / width_t, 0.0, 1.0)
+            R[jj - 1, ii] = wl
+
+    return R
+
+
+def taylor_coeff(
+    x: np.ndarray,
+    N: int,
+    M: int,
+    Ni: np.ndarray,
+    Si: float,
+    period: Union[float, None] = None,
+    xc: Union[np.ndarray, None] = None,
+) -> List[ss.csr_array]:
+    """Return a set of sparse matrices that estimates expansion coefficients.
+
+    Parameters
+    ----------
+    x
+        Positions of each element.
+    N
+        Number of positions each side to estimate from.
+    M
+        The number of terms in the expansion.
+    Ni
+        The weight for each position. The inverse noise variance if interpreted as a
+        Wiener filter.
+    Si
+        A regulariser. The inverse signal variance if interpreted as a Wiener filter.
+    period
+        If set, assume the axis is periodic with this period.
+    xc
+        An optional parameter giving the location to return the coefficients at. If not
+        set, just use the locations of each individual sample.
+
+
+    Returns
+    -------
+    matrices
+        A set of sparse matrices that will estimate the coefficents at each location.
+        Each matrix is for a different coefficient.
+    """
+    nx = x.shape[0]
+
+    ind = np.arange(nx)[:, np.newaxis] + np.arange(-N, N + 1)[np.newaxis, :]
+
+    xc = x if xc is None else xc
+
+    # If periodic then just wrap back around
+    if period is not None:
+        ind = ind % nx
+        xf = x[ind] - xc[:, np.newaxis]
+        x = ((x + period / 2) % period) - period / 2
+        Na = Ni[ind]
+
+    # If not then set the weights for out of bounds entries to zero
+    else:
+        mask = (ind < 0) | (ind >= nx)
+        ind = np.where(mask, 0, ind)
+        xf = x[ind] - x[:, np.newaxis]
+        Na = Ni[ind]
+        Na[mask] = 0.0
+
+    # Create the required matrices at each location
+    X = np.stack([xf**m for m in range(M)], axis=2)
+    XhNi = (X * Na[:, :, np.newaxis]).transpose(0, 2, 1)
+    XhNiX = XhNi @ X
+
+    # Calculate the covariance part of the filter
+    Ci = np.identity(M) * Si + XhNiX
+    C = np.zeros_like(Ci)
+    for i in range(nx):
+        C[i] = la.inv(Ci[i])
+
+    W = C @ XhNi
+
+    # Create the indptr array designating the start and end of the indices for each row
+    # in the csr_array
+    indptr = (2 * N + 1) * np.arange(nx + 1, dtype=int)
+    return [
+        ss.csr_array((W[:, i].ravel(), ind.ravel(), indptr), shape=(nx, nx))
+        for i in range(M)
+    ]


### PR DESCRIPTION
# Summary
Implements a rebinning task similar to #266. This updated version uses the actual per-baseline weights, rather than a mean, and avoids creating a separate `rebin_weight` dataset entirely. This should provide marginally better rebinning behaviour in the presence of bad baselines, and does not require complicated tracking of multiple datasets throughout various pipelines.

It also implements a baseline-dependent `effective_ra` dataset and a simplified `effective_ra` centring correction.

From testing, this seems to show a light reduction in noise across all delays compared to the mean-weighted rebinning.

# Notes
- The rebinning has been tested through the chime daily pipeline
- Gradient correction has been tested
- Stacking of daily data has not been tested, but is assumed to be ok given no issues with daily products
- The addition of a `stack` axis in the `effective_ra` dataset means that containers produced by the old rebinner cannot be loaded with this PR

This PR will replace #266 and would close chime-experiment/ch_pipeline#242 as it is no longer needed.

~Depends on radiocosmology/caput#239 and #231 for updates to container copying behaviour.~ I've decided to implement this in a future PR
