### PR TITLE
Save out multiple files per task and tweak Stokes I RFI task

### DIFF
--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -291,7 +291,10 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
     save = config.Property(default=False, proptype=bool)
 
     output_root = config.Property(default="", proptype=str)
-    output_name = config.Property(default="{output_root}{tag}.h5", proptype=str)
+    output_name = config.Property(
+        default="{output_root}{tag}.h5",
+        proptype=lambda x: x if isinstance(x, list) else str(x),
+    )
     output_format = config.file_format()
     compression = config.Property(
         default=True, proptype=lambda x: x if isinstance(x, dict) else bool(x)
@@ -368,18 +371,25 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
         if output is None:
             return None
 
-        # Insert the input tags into the output container
-        output.attrs["input_tags"] = input_tags
+        # Ensure output is a tuple
+        if not isinstance(output, tuple):
+            output = (output,)
 
-        output = self._process_output(output)
+        # Insert the input tags into the output containers
+        for opt in output:
+            opt.attrs["input_tags"] = input_tags
+
+        # Process each output individually
+        output = tuple(self._process_output(opt, ii) for ii, opt in enumerate(output))
 
         # Increment internal counter
         self._count = self._count + 1
 
         self.log.info(f"Leaving next for task {self.__class__.__name__}")
 
-        # Return the output for the next task
-        return output
+        # Return the output for the next task. If there is
+        # only a single output, don't wrap as a tuple
+        return output if len(output) > 1 else output[0]
 
     def finish(self):
         """Should not need to override. Implement `process_finish` instead."""
@@ -398,20 +408,26 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
             self.log.info(f"Leaving finish for task {class_name}")
             return None
 
-        output = self._process_output(output)
+        # Ensure output is a tuple
+        if not isinstance(output, tuple):
+            output = (output,)
+
+        # Process each output individually
+        output = tuple(self._process_output(opt, ii) for ii, opt in enumerate(output))
 
         self.log.info(f"Leaving finish for task {class_name}")
 
-        return output
+        # If there is only a single output, don't wrap as a tuple
+        return output if len(output) > 1 else output[0]
 
-    def _process_output(self, output):
+    def _process_output(self, output, ii: int = 0):
         if not isinstance(output, memh5.MemDiskGroup):
             raise pipeline.PipelineRuntimeError(
                 f"Task must output a valid memh5 container; given {type(output)}"
             )
 
         # Set the tag according to the format
-        idict = self._interpolation_dict(output)
+        idict = self._interpolation_dict(output, ii)
 
         # Set the attributes in the output container (including from the `tag` config
         # option)
@@ -426,11 +442,11 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
         output = self._nan_process_output(output)
 
         # Write the output if needed
-        self._save_output(output)
+        self._save_output(output, ii)
 
         return output
 
-    def _save_output(self, output: memh5.MemDiskGroup) -> Optional[str]:
+    def _save_output(self, output: memh5.MemDiskGroup, ii: int = 0) -> Optional[str]:
         """Save the output and return the file path if it was saved."""
         if output is None:
             return None
@@ -486,17 +502,21 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
                 output.add_history(key, value)
 
             # Construct the filename
-            name_parts = self._interpolation_dict(output)
+            name_parts = self._interpolation_dict(output, ii)
             if self.output_root != "":
                 self.log.warn("Use of `output_root` is deprecated.")
                 name_parts["output_root"] = self.output_root
-            outfile = self.output_name.format(**name_parts)
+
+            if isinstance(self.output_name, list):
+                outfile = self.output_name[ii].format(**name_parts)
+            else:
+                outfile = self.output_name.format(**name_parts)
 
             # Expand any variables in the path
             outfile = os.path.expanduser(outfile)
             outfile = os.path.expandvars(outfile)
 
-            self.log.debug("Writing output %s to disk.", outfile)
+            self.log.debug(f"Writing output {outfile} to disk.")
             self.write_output(
                 outfile,
                 output,
@@ -531,7 +551,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
 
         return output
 
-    def _interpolation_dict(self, output):
+    def _interpolation_dict(self, output, ii: int = 0):
         # Get the set of variables the can be interpolated into the various strings
         idict = dict(output.attrs)
         if "tag" in output.attrs:
@@ -546,7 +566,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
             count=self._count,
             task=self.__class__.__name__,
             key=(
-                self._out_keys[0]
+                self._out_keys[ii]
                 if hasattr(self, "_out_keys") and self._out_keys
                 else ""
             ),

--- a/draco/util/rfi.py
+++ b/draco/util/rfi.py
@@ -1,7 +1,7 @@
 """Collection of routines for RFI excision."""
 
 import numpy as np
-from scipy.ndimage import convolve1d
+from scipy.ndimage import correlate1d
 
 
 def sumthreshold_py(
@@ -13,11 +13,12 @@ def sumthreshold_py(
     correct_for_missing=True,
     variance=None,
     rho=None,
+    axes=None,
 ):
     """SumThreshold outlier detection algorithm.
 
-    See http://www.astro.rug.nl/~offringa/SumThreshold.pdf for description of
-    the algorithm.
+    See https://andreoffringa.org/pdfs/SumThreshold-technical-report.pdf
+    for description of the algorithm.
 
     Parameters
     ----------
@@ -33,16 +34,20 @@ def sumthreshold_py(
         Subtract the median of the full 2D dataset. Default is True.
     correct_for_missing : bool, optional
         Correct for missing counts
+    variance : np.ndarray[:, :], optional
+        Estimate of the uncertainty on each data point.
+        If provided, then correct_missing=True should be set
+        and threshold1 should be provided in units of "sigma".
     rho : float, optional
         Controls the dependence of the threshold on the window size m,
         specifically threshold = threshold1 / rho ** log2(m).
         If not provided, will use a value of 1.5 (0.9428)
         when correct_missing is False (True).  This is to maintain
         backward compatibility.
-    variance : np.ndarray[:, :], optional
-        Estimate of the uncertainty on each data point.
-        If provided, then correct_missing=True should be set
-        and threshold1 should be provided in units of "sigma".
+    axes : tuple | int, optional
+        Axes of `data` along which to calculate. Flagging is done in
+        the order in which `axes` is provided. By default, loop over
+        all axes in reverse order.
 
     Returns
     -------
@@ -50,7 +55,6 @@ def sumthreshold_py(
         Boolean array, with `True` entries marking outlier data.
     """
     data = np.copy(data)
-    (ny, nx) = data.shape
 
     # If the variance was provided, then we will need to take the
     # square root of the sum of the variances prior to thresholding.
@@ -62,9 +66,17 @@ def sumthreshold_py(
     if rho is None:
         rho = 0.9428 if correct_missing else 1.5
 
-    if start_flag is None:
-        start_flag = np.isnan(data)
-    flag = np.copy(start_flag)
+    if axes is None:
+        # Iterate over axes in reverse order
+        axes = list(range(data.ndim))[::-1]
+    elif isinstance(axes, int):
+        axes = (axes,)
+
+    # By default, flag anything that is not finite (inf and NaN)
+    flag = ~np.isfinite(data)
+
+    if start_flag is not None:
+        flag += start_flag
 
     if remove_median:
         data -= np.median(data[~flag])
@@ -78,58 +90,41 @@ def sumthreshold_py(
         threshold1 = np.percentile(data[~flag], 95.0)
 
     m = 1
+
     while m <= max_m:
-        if m == 1:
-            threshold = threshold1
-        else:
-            threshold = threshold1 / rho ** (np.log2(m))
+        threshold = threshold1 / rho ** (np.log2(m))
 
         # The centre of the window for even windows is the bin right to the left of
         # centre. I want the origin at the leftmost bin
-        if m == 1:
-            centre = 0
-        else:
-            centre = m // 2 - 1
+        centre = (m - 1) // 2
 
-        ## X-axis
+        # Convolution with the kernel is effectively just a windowed sum
+        kernel = np.ones(m, dtype=np.float64)
 
-        data[flag] = 0.0
+        # Loop over axes in order
+        for axis in axes:
+            # Update the data mask
+            data[flag] = 0.0
+            count = (~flag).astype(np.float64) if variance is None else ~flag * variance
 
-        count = (~flag).astype(np.float64) if variance is None else ~flag * variance
+            # Convolve the data and counts with the kernel, extending the
+            # boundaries based on the edge values. Setting `origin=centre`
+            # results in a peak at the *rightmost* edge of the region to
+            # be flagged.
+            dconv = correlate1d(data, kernel, origin=centre, axis=axis, mode="nearest")
+            cconv = correlate1d(count, kernel, origin=centre, axis=axis, mode="nearest")
 
-        # Convolution of the data
-        dconv = convolve1d(data, weights=np.ones(m, dtype=float), origin=centre, axis=1)
+            if correct_for_missing:
+                cconv = cconv**0.5
 
-        # Convolution of the counts
-        cconv = convolve1d(
-            count, weights=np.ones(m, dtype=float), origin=centre, axis=1
-        )
-        if correct_for_missing:
-            cconv = cconv**0.5
-        flag_temp = dconv > cconv * threshold
-        flag_temp += dconv < -cconv * threshold
-        for ii in range(nx - m + 1):
-            flag[:, ii : (ii + m)] += flag_temp[:, ii, np.newaxis]
-
-        ## Y-axis
-
-        data[flag] = 0.0
-
-        count = (~flag).astype(np.float64) if variance is None else ~flag * variance
-
-        # Convolution of the data
-        dconv = convolve1d(data, weights=np.ones(m, dtype=float), origin=centre, axis=0)
-        # Convolution of the counts
-        cconv = convolve1d(
-            count, weights=np.ones(m, dtype=float), origin=centre, axis=0
-        )
-        if correct_for_missing:
-            cconv = cconv**0.5
-        flag_temp = dconv > cconv * threshold
-        flag_temp += dconv < -cconv * threshold
-
-        for ii in range(ny - m + 1):
-            flag[ii : ii + m, :] += flag_temp[ii, np.newaxis, :]
+            temp_flag = np.abs(dconv) > cconv * threshold
+            # Extend the mask to symmetrically cover flagged samples. `origin` is
+            # -centre if m is odd and -centre-1 if m is even. This extends the
+            # flag to the *left* and correctly centers the flagged region
+            origin = m % 2 - centre - 1
+            flag += correlate1d(
+                temp_flag, kernel, origin=origin, axis=axis, mode="nearest"
+            )
 
         m *= 2
 


### PR DESCRIPTION
Three updates:
1. Add functionality for tasks to save multiple outputs
    - The ability for a task to pass along more than one output was added in radiocosmology/caput#258. This update also allows tasks to *save* multiple outputs
2. Remove the second MAD over bright transits and daytime data from the Stokes I RFI mask. This was not behaving well near the edges of heavily flagged regions, and sensitivity-based flagging should be able to catch any RFI that gets through. Also, save out the mean power metric which is used in the sum threshold flagging step so that we can look at it.
3. Update the implementation of `sumthreshold`. This update is mostly to simplify the code, but it also offers a 10-25% speed improvement. NOTE: `ndimage.convolve1d` takes the negative of `origin` and calls `correlate1d` under the hood. By using `correlate1d` directly, we skip that step, which was a bit confusing. 
    - I don't think there's much that can be done to further speed this up other than parallelizing the correlations in cython.