### PR TITLE
fix(analysis.DayenuDelayFilterMap): Remove rms dset

### DIFF
--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -587,6 +587,9 @@ class DayenuDelayFilterMap(task.SingleTask):
 
                 self.log.debug(f"Took {time.time() - t0:0.3f} seconds in total.")
 
+        # Do this due to a bug in MPI IO when distributed over last axis
+        ringmap.redistribute("freq")
+
         return ringmap
 
     def _get_cut(self, el, pol=None, **kwargs):


### PR DESCRIPTION
Redistributing over `el` fails on the `rms` dataset. I tried removing it, but now I'm getting a segfault when it tries to write out the ringmap to disk. So I think there may still be references to the `rms` dataset somewhere.

Any help figuring this out appreciated.