### PR TITLE
Fix visibility gradient correction for quarterstacks

### DIFF
--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -733,6 +733,9 @@ class SiderealStacker(task.SingleTask):
             ):
                 self.stack.add_dataset("sample_variance")
 
+            if "effective_ra" in sdata.datasets:
+                self.stack.add_dataset("effective_ra")
+
             self.stack.redistribute("freq")
 
             # Initialize all datasets to zero.

--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -852,6 +852,20 @@ class SiderealStacker(task.SingleTask):
                 self.stack.nsample[:] > 1, tools.invert_no_zero(norm), 0.0
             )[np.newaxis, :]
 
+        if "effective_ra" in self.stack.datasets:
+            # For samples where there is no data, the effective ra should
+            # be the same as the grid ra
+            weight = self.stack.weight[:].local_array
+            era = self.stack.effective_ra[:].local_array
+
+            # Broadcast the RA array to match the shape of a single frequency,
+            # allowing us to select grid ra values with a 2D mask
+            grid_ra = np.broadcast_to(self.stack.ra, (*era.shape[1:],))
+
+            for fi in range(era.shape[0]):
+                mask = weight[fi] == 0.0
+                era[fi][mask] = grid_ra[mask]
+
         return self.stack
 
 

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1218,7 +1218,7 @@ class MixData(task.SingleTask):
             self.mixed_data.weight[:] = 0.0
 
         # Validate the types are the same
-        if type(self.mixed_data) != type(data):
+        if type(self.mixed_data) is not type(data):
             raise TypeError(
                 f"type(data) (={type(data)}) must match "
                 f"type(data_stack) (={type(self.type)}"


### PR DESCRIPTION
Multiple fixes for tracking effective ra and applying a gradient correction:
- Initialize the `effective_ra` dataset in the stack container
- Properly replace the effective ra of masked samples with the bin centre ra
- Handle NaN values in the visibility gradient where the ra step is 0