### PR TITLE
Change DPS time_frac and remove_mean defaults to have more expected behaviour

### DIFF
--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -403,9 +403,9 @@ class DelayTransformBase(task.SingleTask):
     weight_boost = config.Property(proptype=float, default=1.0)
 
     freq_frac = config.Property(proptype=float, default=0.0)
-    time_frac = config.Property(proptype=float, default=-1.0)
+    time_frac = config.Property(proptype=float, default=0.0)
 
-    remove_mean = config.Property(proptype=bool, default=False)
+    remove_mean = config.Property(proptype=bool, default=True)
     scale_freq = config.Property(proptype=bool, default=False)
 
     def process(self, ss):


### PR DESCRIPTION
We originally set these defaults to try to mimic the behaviour of the old Delay Power Spectrum code. However, that behaviour can't be reproduced exactly, since it would end up multiplying a mask into the data (no matter how complex), and instead we ended up introducing default behaviour which would not mask in RA. 