### PR TITLE
feat(transform): update MixData to enable jackknifes

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1351,7 +1351,7 @@ class MixData(task.SingleTask):
 
         # Update the flag
         if self.require_nonzero_weight:
-            self._flag &= (data.weight[:] > 0.0)
+            self._flag &= data.weight[:] > 0.0
 
         # Save the tags
         if "tag" in data.attrs:


### PR DESCRIPTION
MixData contains much of the functionality needed to perform a jackknife of two datasets.  This adds two config flags that (1) will invert the weights prior to mixing and so that uncertainty is propagated correctly and (2) flags any samples where the weight is zero in any of the input data.  It also creates a new Jackknife task that has the config properties set to the correct values for performing a jackknife of two datasets.