### PR TITLE
Truncation weight broadcasting and get weights from a property

### DIFF
--- a/draco/analysis/sensitivity.py
+++ b/draco/analysis/sensitivity.py
@@ -61,7 +61,7 @@ class ComputeSystemSensitivity(task.SingleTask):
 
         if "gain" in data.datasets:
             # Derive frequency dependent flags from gains
-            gainflg = data.gain[:].view(np.ndarray) != (1.0 + 0.0j)
+            gainflg = data.gain[:].local_array != (1.0 + 0.0j)
             inpflg = np.swapaxes(inpflg[np.newaxis, :, :] & gainflg, 0, 1)
             # Flatten frequency and time axis so we can use numpy's unique
             inpflg = inpflg.reshape(inpflg.shape[0], -1)
@@ -155,7 +155,7 @@ class ComputeSystemSensitivity(task.SingleTask):
             )
 
         # Dereference the weight dataset
-        bweight = data.weight[:].view(np.ndarray)
+        bweight = data.weight[:].local_array
         bflag = bweight > 0.0
 
         # Initialize arrays

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -506,17 +506,21 @@ class ElevationDependentHybridVisWeight(task.SingleTask):
         data
             Input container with different weights dataset
         """
-        weights = data.weight[:].local_array
+        data.redistribute("freq")
 
-        # Remove the reference to the vis_weight dataset
-        del data["vis_weight"]
-
-        # Add the new elevation-dependent weight dataset
-        data.add_dataset("elevation_vis_weight")
-
-        # Write the weights into the new dataset, broadcasting over
-        # the elevation axis
-        data.weight[:].local_array[:] = weights[..., np.newaxis, :]
+        # if elevation-dependent weights alread exist, this
+        # should be a no-op and just pass the dataset along
+        if "elevation_vis_weight" in data:
+            self.log.debug("Container already has the required dataset.")
+        else:
+            weights = data["vis_weight"][:].local_array
+            # Remove the reference to the vis_weight dataset
+            del data["vis_weight"]
+            # Add the new elevation-dependent weight dataset
+            data.add_dataset("elevation_vis_weight")
+            # Write the weights into the new dataset, broadcasting over
+            # the elevation axis
+            data.weight[:].local_array[:] = weights[..., np.newaxis, :]
 
         return data
 

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -854,13 +854,12 @@ class Truncate(task.SingleTask):
                         val, specs["fixed_precision"]
                     ).reshape(old_shape)
             else:
-                invvar = (
-                    np.broadcast_to(
-                        data[specs["weight_dataset"]][:], data[dset][:].shape
-                    )
-                    .copy()
-                    .reshape(-1)
-                )
+                if hasattr(data, specs["weight_dataset"]):
+                    invvar = getattr(data, specs["weight_dataset"])
+                else:
+                    invvar = data[specs["weight_dataset"]][:]
+
+                invvar = np.broadcast_to(invvar, data[dset][:].shape).copy().reshape(-1)
                 invvar *= (2.0 if np.iscomplexobj(data[dset]) else 1.0) / specs[
                     "variance_increase"
                 ]

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -841,6 +841,7 @@ class Truncate(task.SingleTask):
             # np.ndarray.reshape must be used with ndarrays
             # MPIArrays use MPIArray.reshape()
             val = np.ndarray.reshape(data[dset][:].view(np.ndarray), data[dset][:].size)
+
             if specs["weight_dataset"] is None:
                 if np.iscomplexobj(data[dset]):
                     data[dset][:].real = truncate.bit_truncate_relative(
@@ -854,15 +855,27 @@ class Truncate(task.SingleTask):
                         val, specs["fixed_precision"]
                     ).reshape(old_shape)
             else:
+                # If possible, extract the weight dataset from
+                # an attribute
                 if hasattr(data, specs["weight_dataset"]):
                     invvar = getattr(data, specs["weight_dataset"])
                 else:
-                    invvar = data[specs["weight_dataset"]][:]
+                    wdset = data[specs["weight_dataset"]]
+                    # Add missing axes to the weights dataset if
+                    # needed and if possible
+                    waxes = wdset.attrs.get("axis", [])
+                    daxes = data[dset].attrs.get("axis", [])
+                    # Add length-one axes
+                    slobj = tuple(
+                        slice(None) if ax in waxes else np.newaxis for ax in daxes
+                    )
+                    invvar = wdset[:][slobj]
 
                 invvar = np.broadcast_to(invvar, data[dset][:].shape).copy().reshape(-1)
                 invvar *= (2.0 if np.iscomplexobj(data[dset]) else 1.0) / specs[
                     "variance_increase"
                 ]
+
                 if np.iscomplexobj(data[dset]):
                     data[dset][:].real = truncate.bit_truncate_weights(
                         val.real,


### PR DESCRIPTION
Pulls some useful functionality from #259.

These commits are required when to broadcast weights when compressing a `HybridVisStream`, but were previously contained in a much larger PR