### PR TITLE
DPSS inpainting and FFT delay transform

### DIFF
--- a/draco/analysis/interpolate.py
+++ b/draco/analysis/interpolate.py
@@ -1,0 +1,411 @@
+"""Tasks to do data interpolation/inpainting."""
+
+import numpy as np
+from caput import config, mpiutil
+from cora.util import units
+
+from ..core import io, task
+from ..util import dpss
+
+
+class DPSSInpaint(task.SingleTask):
+    """Fill data gaps using DPSS inpainting.
+
+    Discrete prolate spheroidal sequence (DPSS) inpainting involves
+    projecting a partially-masked data series onto a basis which
+    maximally concentrates spectral power within a defined window.
+    This basis, called the nth order discrete prolate spheroidal
+    sequence or Slepian sequence consists of the large eigenvectors
+    of a covariance matrix defined as a sum of `sinc` functions,
+    which represent top-hats in the spectral inverse of the data.
+
+    This class is fully-functional, but only supports applying a
+    constant cutoff.
+
+    Attributes
+    ----------
+    axis : str
+        Name of the axis over which to inpaint. Only one-dimensional
+        inpainting is currently supported. Must be either "freq" or
+        "ra". Default is `freq`.
+    iter_axes : list[str]
+        List of independent axes over which to iterate. This can
+        include axes not in the dataset, but at least one of these
+        axes should be present. Default is ["stack", "el"].
+    centres : list
+        List of top-hat window centres. If all windows are centred
+        about zero, the covariance matrix will be real, which provides
+        significant performance improvements.
+    halfwidths : list
+        List of window half-widths. Must be the same length as `centres`.
+    snr_cov : float
+        Wiener filter inverse signal covariance. Default is 1.0e-3.
+    flag_above_cutoff : bool
+        Re-flag gaps in the data above the width specified by
+        cutoff_frac * fs / max(halfwidths), where fs is the
+        sample rate. Default is True.
+    cutoff_frac : float
+        Fraction of the cutoff used when re-flagging inpainted
+        samples. Default is 1.0.
+    copy : bool
+        If true, copy the container instead of inpainting in-place.
+    """
+
+    axis = config.enum(["freq", "ra"], default="freq")
+    iter_axes = config.Property(proptype=list, default=["stack", "el"])
+    centres = config.Property(proptype=list)
+    halfwidths = config.Property(proptype=list)
+    snr_cov = config.Property(proptype=float, default=1.0e-3)
+    flag_above_cutoff = config.Property(proptype=bool, default=True)
+    cutoff_frac = config.Property(proptype=float, default=1.0)
+    copy = config.Property(proptype=bool, default=True)
+
+    def setup(self, mask=None):
+        """Use an optional mask dataset.
+
+        Parameters
+        ----------
+        mask : containers.RFIMask, optional
+            Container used to select samples to inpaint. If
+            not provided, inpaint samples where the data
+            weights are zero.
+        """
+        self.mask = mask
+
+    def process(self, data):
+        """Inpaint visibility data.
+
+        Parameters
+        ----------
+        data : containers.VisContainer
+            Container with a visibility dataset
+
+        Returns
+        -------
+        data : containers.VisContainer
+            Input container with masked values filled
+        """
+        try:
+            # Get the axis samples
+            samples = getattr(data, self.axis)
+        except AttributeError as exc:
+            raise ValueError(f"Could not get axis `{self.axis}`.") from exc
+
+        # Redistribute over an independent axis
+        data.redistribute(self.iter_axes)
+        # Set the local selection over the distributed axis
+        self._set_sel(data)
+
+        vinp, winp = self.inpaint(data.vis, data.weight, samples)
+
+        # Make the output container
+        if self.copy:
+            # Trying to copy a dataset while distributed
+            # over a non-contiguous axis (time/ra in this case)
+            # hangs almost indefinitely. We need to distribute
+            # over a different axis before copying.
+            data.redistribute("freq")
+            out = data.copy()
+            out.redistribute(self.iter_axes)
+        else:
+            out = data
+
+        out.vis[:].local_array[:] = vinp
+        out.weight[:].local_array[:] = winp
+
+        return out
+
+    def inpaint(self, vis, weight, samples):
+        """Inpaint visibilities using a wiener filter.
+
+        Use a single sequence for the entire dataset.
+        """
+        # Move the iteration and interpolation axes
+        # to the front and flatten the other axes
+        vobs, vaxind = _flatten_axes(vis, (*self.iter_axes, self.axis))
+        wobs, waxind = _flatten_axes(weight, (*self.iter_axes, self.axis))
+
+        if self.mask is not None:
+            mobs, _ = _flatten_axes(self.mask.mask, (*self.iter_axes, self.axis))
+            # Invert the mask to avoid doing it every loop
+            mobs = ~mobs
+
+        # Pre-allocate the full output array
+        vinp = np.zeros_like(vobs)
+        winp = np.zeros_like(wobs)
+
+        # Construct the covariance matrix and get dpss modes
+        modes, amap, cutoff = self._get_basis(samples)
+
+        # Iterate over the variable axis
+        for ii in range(vobs.shape[0]):
+            # Get the correct basis for each slice
+            A = modes[amap[ii]]
+
+            # Get a selection for data to keep
+            M = wobs[ii] > 0
+            W = mobs if self.mask is not None else M
+
+            vinp[ii], winp[ii] = dpss.inpaint(vobs[ii], wobs[ii], A, W, self.snr_cov)
+
+            # Re-flag gaps above the cutoff width
+            if self.flag_above_cutoff:
+                winp[ii] *= dpss.flag_above_cutoff(M, cutoff)
+
+        # Reshape and move the interpolation axis back
+        vinp = _inv_move_front(vinp, vaxind, vis.local_shape)
+        winp = _inv_move_front(winp, waxind, weight.local_shape)
+
+        return vinp, winp
+
+    def _set_sel(self, data):
+        """Extract selection along local axis."""
+        self._local_sel = data.vis[:].local_bounds
+
+    def _get_basis(self, samples):
+        """Make the DPSS basis.
+
+        Returns a list of bases and a map.
+        """
+        # Construct the covariance matrix and get dpss modes
+        cov = dpss.make_covariance(samples, self.halfwidths, self.centres)
+        modes = dpss.get_basis(cov)
+        # All iterations map to the same basis
+        amap = [0] * (self._local_sel.stop - self._local_sel.start)
+
+        # Flagging cutoff
+        fs = 1 / np.median(abs(np.diff(samples)))
+        cutoff = self.cutoff_frac * fs / np.max(self.halfwidths)
+
+        return [modes], amap, cutoff
+
+
+class DPSSInpaintBaseline(DPSSInpaint):
+    """Inpaint with baseline-dependent cut.
+
+    This is a non-functional base class which provides functionality
+    for selecting the correct baselines and making a set of unique
+    basis functions.
+
+    Users should override the `_get_cuts` method to make baseline-
+    dependent cuts along the desired axis.
+
+    Attributes
+    ----------
+    telescope_orientation : one of ('NS', 'EW', 'none')
+        Determines if the baseline-dependent delay cut is based on the north-south
+        component, the east-west component or the full baseline length. For
+        cylindrical telescopes oriented in the NS direction (like CHIME) use 'NS'.
+        The default is 'NS'.
+    """
+
+    telescope_orientation = config.enum(["NS", "EW", "none"], default="NS")
+
+    def setup(self, telescope, mask=None):
+        """Load a telescope object.
+
+        Parameters
+        ----------
+        telescope : TransitTelescope
+            Telescope object with baseline information.
+        mask : containers.RFIMask, optional
+            Container used to select samples to inpaint. If
+            not provided, inpaint samples where the data
+            weights are zero.
+        """
+        self.telescope = io.get_telescope(telescope)
+        # Pass the mask to the parent class
+        super().setup(mask)
+
+    def _set_sel(self, data):
+        """Set the local baselines."""
+        prod = data.prodstack
+        sel = self.telescope.feedmap[(prod["input_a"], prod["input_b"])]
+
+        self._baselines = self.telescope.baselines[sel]
+
+    def _get_basis(self, samples):
+        """Make the DPSS basis for each unique delay cut.
+
+        Returns a list of bases and a map.
+        """
+        # Get cutoffs for each baseline
+        cuts = self._get_baseline_cuts()
+
+        # Compute covariances for each unique baseline and
+        # map to each individual baseline.
+        cuts, amap = np.unique(cuts, return_inverse=True)
+
+        modes = []
+
+        for ii, cut in enumerate(cuts):
+            self.log.debug(
+                f"Making unique covariance {ii+1}/{len(cuts)} with cut={cut}."
+            )
+            cov = dpss.make_covariance(samples, cut, 0.0)
+            modes.append(dpss.get_basis(cov))
+
+        # Flagging cutoff
+        fs = 1 / np.median(abs(np.diff(samples)))
+        cutoff = self.cutoff_frac * fs / np.max(cuts)
+        # Need the mask to be the same for all baselines,
+        # so use the most aggressive masking
+        cutoff = mpiutil.allreduce(cutoff, op=mpiutil.MIN)
+
+        return modes, amap, cutoff
+
+    def _get_baseline_cuts(self):
+        """Get an array of cutoffs for each baseline."""
+        raise NotImplementedError()
+
+
+class DPSSInpaintDelay(DPSSInpaintBaseline):
+    """Inpaint with baseline-dependent delay cut.
+
+    Attributes
+    ----------
+    axis : str
+        Name of axis over which to inpaint. `freq` is the only
+        accepted argument.
+    za_cut : float
+        Sine of the maximum zenith angle included in baseline-dependent delay
+        filtering. Default is 1 which corresponds to the horizon (ie: filters out all
+        zenith angles). Setting to zero turns off baseline dependent cut.
+    extra_cut : float
+        Increase the delay threshold beyond the baseline dependent term.
+    telescope_orientation : one of ('NS', 'EW', 'none')
+        Determines if the baseline-dependent delay cut is based on the north-south
+        component, the east-west component or the full baseline length. For
+        cylindrical telescopes oriented in the NS direction (like CHIME) use 'NS'.
+        The default is 'NS'.
+    """
+
+    axis = config.enum(["freq"], default="freq")
+    za_cut = config.Property(proptype=float, default=1.0)
+    extra_cut = config.Property(proptype=float, default=0.0)
+
+    def _get_baseline_cuts(self):
+        """Get an array of delay cuts."""
+        # Calculate delay cuts based on telescope orientation
+        if self.telescope_orientation == "NS":
+            blen = abs(self._baselines[:, 1])
+        elif self.telescope_orientation == "EW":
+            blen = abs(self._baselines[:, 0])
+        else:
+            blen = np.linalg.norm(self._baselines, axis=1)
+
+        # Get the delay cut for each baseline. Round delay cuts
+        # to three decimal places to reduce repeat calculations
+        delay_cut = self.za_cut * blen / units.c * 1.0e6 + self.extra_cut
+        delay_cut = np.maximum(delay_cut, self.halfwidths[0])
+
+        return np.round(delay_cut, decimals=3)
+
+
+class DPSSInpaintMMode(DPSSInpaintBaseline):
+    """Inpaint with a baseline-dependent m cut.
+
+    Attributes
+    ----------
+    axis : str
+        Name of axis over which to inpaint. `freq` is the only
+        accepted argument.
+    """
+
+    axis = config.enum(["ra"], default="ra")
+
+    def _get_baseline_cuts(self):
+        """Make the DPSS basis for each unique m cut.
+
+        Returns a list of bases and a map.
+        """
+        # Calculate cuts based on telescope orientation.
+        # Note that this is opposite from the baseline
+        # component used for delay, since we care
+        # about the direction of fringing here
+        if self.telescope_orientation == "NS":
+            blen = abs(self._baselines[:, 0])
+        elif self.telescope_orientation == "EW":
+            blen = abs(self._baselines[:, 1])
+        else:
+            blen = np.linalg.norm(self._baselines, axis=1)
+
+        # Get highest frequency in MHz
+        freq = self.telescope.freq_start
+        dec = np.deg2rad(self.telescope.latitude)
+        # Cut at the maximum `m` expected for each baseline.
+        # Compensate for the fact the ra samples is in degrees
+        mcut = (np.pi / 180) * freq * 1e6 * blen / (units.c * np.cos(dec))
+        mcut = np.maximum(mcut, self.halfwidths[0])
+
+        return np.round(mcut, decimals=2)
+
+
+class StokesIMixin:
+    """Change baseline selection assuming Stokes I only."""
+
+    def _set_sel(self, data):
+        """Set the local baselines."""
+        # Baseline lengths extracted from the stack axis
+        self._baselines = data.stack[data.vis[:].local_bounds]
+
+
+class DPSSInpaintDelayStokesI(StokesIMixin, DPSSInpaintDelay):
+    """Inpaint Stokes I with baseline-dependent delay cut."""
+
+
+class DPSSInpaintMModeStokesI(StokesIMixin, DPSSInpaintMMode):
+    """Inpaint Stokes I with baseline-dependent m-mode cut."""
+
+
+def _flatten_axes(data, axes):
+    """Move the specified axes to the front of a dataset.
+
+    Not all the axes in `axes` need to be present, but at
+    least one must exist
+    """
+    dax = list(data.attrs["axis"])
+
+    axind = [dax.index(axis) for axis in axes if axis in dax]
+
+    if not axind:
+        raise ValueError(
+            f"No matching axes. Dataset has axes {dax}, "
+            f"but axes {axes} were requested."
+        )
+
+    ds = data[:].view(np.ndarray)
+
+    return _move_front(ds, axind, ds.shape), axind
+
+
+def _move_front(arr: np.ndarray, axis: int | list, shape: tuple) -> np.ndarray:
+    """Move specified axes to the front and flatten remaining axes."""
+    if np.isscalar(axis):
+        axis = [axis]
+
+    new_shape = [shape[i] for i in axis]
+    # Move the N specified axes to the first N positions
+    inds = list(range(len(axis)))
+    # Move the specified axes to the front and flatten
+    # the remaining axes
+    arr = np.moveaxis(arr, axis, inds)
+
+    return arr.reshape(*new_shape, -1)
+
+
+def _inv_move_front(arr: np.ndarray, axis: int | list, shape: tuple) -> np.ndarray:
+    """Move axes back to their original position and expand."""
+    if np.isscalar(axis):
+        axis = [axis]
+
+    new_shape = [shape[i] for i in axis]
+    new_shape += [sh for sh in shape if sh not in new_shape]
+    inds = list(range(len(axis)))
+
+    # Undo the flattening process
+    arr = arr.reshape(new_shape)
+    # Move axes back to their original positions
+    arr = np.moveaxis(arr, inds, axis)
+
+    return arr.reshape(shape)

--- a/draco/util/dpss.py
+++ b/draco/util/dpss.py
@@ -1,0 +1,521 @@
+"""Routines for DPSS inpainting."""
+
+import numpy as np
+from caput.tools import invert_no_zero
+from scipy import interpolate
+from scipy import linalg as la
+
+
+def make_covariance(
+    samples: np.ndarray,
+    halfwidths: list[float],
+    centres: list[float],
+) -> np.ndarray:
+    """Make a signal covariance model.
+
+    Assumes the signal is a sum of top-hats in fourier
+    space with centres at `centres` and half-widths
+    in `halfwidths`.
+
+    Parameters
+    ----------
+    samples
+        Samples corresponding to the signal measurements
+    halfwidths
+        List of window half-widths in units defined by the
+        fourier inverse of `samples`. Must be the same length
+        as `centres`.
+    centres
+        List of window centres in units defined by the fourier
+        inverse of `samples`. Must be the sample length as
+        `halfwidths`.
+
+    Returns
+    -------
+    cov
+        Model for the signal covariance. If all entries in
+        `centres` are zero, this is a real array. Otherwise,
+        it is complex.
+    """
+    if np.isscalar(halfwidths):
+        halfwidths = [halfwidths]
+
+    if np.isscalar(centres):
+        centres = [centres]
+
+    if len(centres) != len(halfwidths):
+        raise ValueError(
+            "`halfwidths` and `centres` must be the same length. "
+            f"Got halfwidths={halfwidths}, centres={centres}"
+        )
+
+    # Create a grid of the outer difference of samples
+    ds = np.subtract.outer(samples, samples)
+    cov = np.zeros(ds.shape, dtype=np.complex128)
+
+    for ct, hw in zip(centres, halfwidths):
+        cov += np.exp(-2.0j * np.pi * ct * ds) * np.sinc(2.0 * hw * ds)
+
+    # If the covariance is entirely real, return a real-type
+    # array since this is always computationally faster to use
+    if np.isreal(cov).all():
+        cov = np.ascontiguousarray(cov.real)
+
+    return cov
+
+
+def get_basis(
+    cov: np.ndarray, threshold: float = 1e-12, dtype: np.dtype = np.float32
+) -> np.ndarray:
+    """Compute the nth order Slepian sequence (DPSS).
+
+    Order `n` is selected as the number of eigenvalues of
+    `cov` greater than threshold when normalized by the
+    largest eigenvalue.
+
+    Parameters
+    ----------
+    cov
+        Signal covariance model, constructed as a sum of
+        top-hats.
+    threshold
+        Eigenvalue cutoff relative to the largest eigenvalue.
+        Default is 1e-12.
+    dtype
+        Data type of the output sequence. This casting happens
+        AFTER the eigen decomposition and eigenvalue
+        threshold cut. If `cov` is complex, a datatype will
+        correspond to the datatype of the REAL component - i.e. if
+        `cov` is complex and `dtype=np.float32`, output sequence
+        will have type `np.complex64`.
+
+    Returns
+    -------
+    basis
+        Eigenvectors corresponding to eigenvalues larger than
+        `threshold` times the largest eigenvalue.
+    """
+    # Using the `evd` driver seems to be significantly faster
+    # than other drivers for the types of matrices we're
+    # using here. If this ever seems to become a rate-limiting
+    # step, try using the `evr` driver instead.
+    evals, evecs = la.eigh(cov, check_finite=False, driver="evd")
+    idx = np.argsort(evals)[::-1]
+
+    # Sort the values and vectors by decreasing
+    # eigenvalue magnitude
+    evals = evals[idx]
+    evecs = evecs[:, idx]
+
+    nmodes = (evals > threshold * evals.max()).sum()
+
+    # Figure out the output datatype
+    if np.iscomplexobj(evecs):
+        dtype = _dtype_to_complex(dtype)
+    else:
+        dtype = _dtype_to_real(dtype)
+
+    return evecs[:, :nmodes].astype(dtype)
+
+
+def project(x: np.ndarray, Ni: np.ndarray, A: np.ndarray) -> np.ndarray:
+    """Project noise-weighted data into the DPSS basis.
+
+    This can be thought of as the right half of a wiener filter.
+
+
+    Parameters
+    ----------
+    x
+        Data to be interpolated.
+    Ni
+        Inverse noise variance associated with each sample,
+        with masked values set to zero.
+    A
+        dpss basis, assumed to be the output of `get_basis`.
+
+    Returns
+    -------
+    xproj
+        Noise-weighted data projected into the dpss basis.
+    """
+    # Make sure these arrays are at least 2d,
+    # which is helpful to make these operations consistant
+    x, _ = atleast_Nd(x, 2)
+    Ni, _ = atleast_Nd(Ni, 2)
+
+    # Assuming `A` is given directly as the output of
+    # `get_basis`, the conjugate transpose is needed
+    AT = A.T.conj()
+
+    return AT @ (Ni * x)
+
+
+def solve(
+    xp: np.ndarray, Ni: np.ndarray, A: np.ndarray, Si: float = 1e-3
+) -> list[np.ndarray, np.ndarray]:
+    """Apply the inpainting operator to data.
+
+    Returns the inpainted data and corresponding inverse
+    variance weight estimate. Only the diagonal of the
+    covariance is returned, for computational reasons.
+
+    Parameters
+    ----------
+    xp
+        Noise-weighted data projected into the dpss basis,
+        assumed to be the output of `project`
+    Ni
+        Inverse-variance noise weights.
+    A
+        dpss basis, assumed to be the output of `get_basis`.
+    Si
+        Regularizer, treated as the expected typical inverse
+        signal variance in a Wiener filter. The default value
+        of 1e-3 seems to work quite well, so it should be
+        changed with caution.
+
+    Returns
+    -------
+    xinp
+        Inpainted data.
+    winp
+        Inverse of the diagonal of the uncertainty matrix.
+    """
+    AT = A.T.conj()
+    # Check the shape of `xp` and `Ni` and move axes
+    # if necessary to match `A`. Keep the original axis
+    # position so it can be reverted later. It's faster to
+    # copy than it is to iterate over a non-contiguous array
+    xp, si = _check_shape(xp, AT, copy=True)
+    Ni, _ = _check_shape(Ni, A, copy=True)
+    # Ensure that `xp` and `Ni` are at least two
+    # dimensional so we can iterate over the first axis
+    xp, inv = atleast_Nd(xp, N=2, lax=0)
+    Ni, _ = atleast_Nd(Ni, N=2, lax=0)
+
+    b = np.zeros_like(xp)
+
+    # Figure out which datatype to use depending
+    # on whether or not `A` is complex
+    cho_dtype = np.float32
+    if np.iscomplexobj(A):
+        cho_dtype = _dtype_to_complex(cho_dtype)
+
+    # Iterate over the first axis
+    for ii in range(xp.shape[0]):
+        Ni_ii = Ni[ii].astype(A.dtype)
+
+        if np.all(Ni_ii == 0):
+            continue
+
+        ATNi = AT * Ni_ii[np.newaxis]
+
+        # Make the covariance matrix
+        Ci = ATNi @ A
+        # Add a diagonal regulariser to the covariance.
+        # In a weiner filter, this is the signal covariance.
+        # Use einsum trick to get a view of the diagonal.
+        np.einsum("ii->i", Ci)[:] += Si
+        # Cholesky decomposition. This is faster than
+        # doing a standard solve, and significantly
+        # faster than an inverse
+        CiL = la.cho_factor(Ci.astype(cho_dtype), lower=False, check_finite=False)
+
+        # Solve for the data projection coefficient
+        b[ii] = la.cho_solve(CiL, xp[ii], check_finite=False)
+
+        # Solve for beta part of the the inpainting operator
+        # F = A (Si^{-1} + A^{H} Ni A)^{-1} A^{H} Ni
+        # where F = A @ beta
+        # Only save the diagonal component of the resulting
+        # covariance. This can be done faster using a fancy
+        # einsum than by doing the individual matrix mults,
+        # but it's still the slowest step here so it might
+        # be worth writing some custom cython or numba
+        beta = la.cho_solve(CiL, ATNi, check_finite=False)
+
+        betaT = beta.T.conj()
+        N_ii = invert_no_zero(Ni_ii)
+        var = np.einsum("ik,kj,j,jm,mi->i", A, beta, N_ii, betaT, AT, optimize="greedy")
+
+        # Save out the inverse variance weights. Technically,
+        # we should be making the full covariance matrix,
+        # inverting that, then taking the resuling diagonal,
+        # but that isn't computationally feasible
+        Ni[ii] = invert_no_zero(var)
+
+    # Construct the interpolated data
+    x = A @ np.moveaxis(b[inv], -1, si)
+
+    return x, np.moveaxis(Ni[inv], -1, si)
+
+
+def accumulate_variance(wo: np.ndarray, wi: np.ndarray, W: np.ndarray) -> np.ndarray:
+    """Pchip interpolate and accumulate weights.
+
+    Pchip seems to behave reasonably well around boundaries
+    and large spikes.
+
+    Parameters
+    ----------
+    wo
+        Non-inpainted inverse variance weights. These
+        will be interpolated
+    wi
+        Inpainted weights, assumed to be output from `solve`
+    W
+        Boolean masking matrix, where False values correspond
+        to flagged data in `wo` which need to be interpolated.
+
+    Returns
+    -------
+    wacc
+        Inverse variance weights accumulated after interpolating.
+    """
+    # Interpolate variances. This seems to produce
+    # better edge behaviour
+    vo = invert_no_zero(wo)
+    vi = invert_no_zero(wi)
+
+    samples = np.arange(vo.shape[0])
+
+    # Iterate over the last axis
+    for ii in range(vo.shape[-1]):
+        sel = W[:, ii]
+
+        if sel.sum() < 2:
+            # Need a minimum number of samples
+            # to interpolate
+            continue
+
+        # Interpolate. Pchip seems to work reasonably well
+        # over small gaps without producing any crazy effects
+        # over large gaps and edges.
+        pchip = interpolate.PchipInterpolator(
+            samples[sel], vo[:, ii][sel], extrapolate=True
+        )
+        # Handle extrapolation errors.
+        wint = pchip(samples)
+        wint[wint < 0] = 0
+        # Accumulate
+        vi[:, ii] += wint
+
+    return invert_no_zero(vi)
+
+
+def flag_above_cutoff(W: np.ndarray, fc: float) -> np.ndarray:
+    """Mask to flag inpainted gaps wider than the cutoff `fc`.
+
+    Calculates the width of each flagged region along the last axis,
+    and returns a mask which is False for gaps larger than those
+    that can be reasonably interpolated by a covariance with a
+    certain cutoff.
+
+    Parameters
+    ----------
+    W
+        Original mask array, False where samples are flagged.
+    fc
+        Cutoff width, in units of samples. Gaps above this
+        value are flagged.
+
+    Returns
+    -------
+    mask
+        Mask with gaps larger than `fc` flagged, where
+        False corresponds to flagged values.
+    """
+    M = ~W
+    dist = np.zeros_like(W, dtype=np.float32)
+    # Get the rising and falling edge of flagged regions
+    rise = np.diff(M, axis=0, prepend=False) & M
+    rise = rise[:-1]
+    fall = np.diff(W, axis=0, append=False) & M
+
+    # Get the leftmost and rightmost data boundaries,
+    # assuming that we can't extrapolate
+    lbound = np.argmax(W, axis=0)
+    rbound = W.shape[0] - np.argmax(W[::-1], axis=0) - 1
+
+    # This works, but maybe isn't optimally fast
+    for ii in range(M.shape[-1]):
+        rind = np.flatnonzero(rise[:, ii])
+        find = np.flatnonzero(fall[:, ii])
+
+        for ri, fi in zip(rind, find):
+            dist[ri : fi + 1, ii] = fi - ri
+
+        dist[: lbound[ii], ii] = 2 * fc
+        dist[rbound[ii] :, ii] = 2 * fc
+
+    return dist < fc
+
+
+def filter(
+    x: np.ndarray, Ni: np.ndarray, A: np.ndarray, W: np.ndarray, Si: float = 1e-3
+) -> np.ndarray:
+    """Filter using a DPSS basis over the first axis.
+
+    Parameters
+    ----------
+    x
+        Data to filter. Can be Real or Complex.
+    Ni
+        Inverse variance noise weights for each sample in `x`.
+    A
+        dpss basis, assumed to be the output of `get_basis`.
+    W
+        Mask array, where False values will be replaced by
+        inpainted data.
+    Si
+        Regularizer, treated as the expected typical inverse
+        signal variance in a Wiener filter. The default value
+        of 1e-3 seems to work quite well, so it should be
+        changed with caution.
+
+    Returns
+    -------
+    xfilt
+        Filtered data.
+    wfilt
+        Filtered inverse variance weights.
+    """
+    # Subtract the mean data before inpainting and
+    # re-add at the end
+    xhat = np.sum(x * W, axis=0, keepdims=True)
+    xhat *= invert_no_zero(np.sum(W, axis=0, keepdims=True))
+
+    # Make the data projection
+    xp = project(x - xhat, Ni, A)
+    # Make the inpainted data
+    xfilt, wfilt = solve(xp, Ni, A, Si)
+
+    # Interpolate and accumulate variances
+    wfilt = accumulate_variance(Ni, wfilt, W)
+
+    # Re-add the mean
+    xfilt += xhat
+
+    return xfilt, wfilt
+
+
+def inpaint(
+    x: np.ndarray, Ni: np.ndarray, A: np.ndarray, W: np.ndarray, Si: float = 1e-3
+) -> np.ndarray:
+    """Inpaint using a DPSS basis over the first axis.
+
+    Parameters
+    ----------
+    x
+        Data to interpolate. Can be Real or Complex.
+    Ni
+        Inverse variance noise weights for each sample in `x`.
+    A
+        dpss basis, assumed to be the output of `get_basis`.
+    W
+        Mask array, where False values will be replaced by
+        inpainted data.
+    Si
+        Regularizer, treated as the expected typical inverse
+        signal variance in a Wiener filter. The default value
+        of 1e-3 seems to work quite well, so it should be
+        changed with caution.
+
+    Returns
+    -------
+    xinp
+        Inpainted data. Samples where `W` is True are not changed
+        from the input data.
+    winp
+        Inpainted inverse variance weights. Samples where `W` is True
+        are not changed from the input data.
+    """
+    xinp, winp = filter(x, Ni, A, W, Si)
+
+    xinp[W] = x[W]
+    winp[W] = Ni[W]
+
+    return xinp, winp
+
+
+def atleast_Nd(x: np.ndarray, N: int, lax: int = -1):
+    """Ensure that an array is at least `N` dimensional.
+
+    Unlike `np.atleast_2d` and similar, this allows the user
+    to select the location where new axes are inserted. New axes
+    are always grouped together. If `x.ndim` is greater or equal to
+    `N`, `x` is returned unchanged.
+
+    Parameters
+    ----------
+    x
+        Array to expend dimensions.
+    N
+        Desired dimension of `x`.
+    lax
+        Axis to the left of where the new axes
+        are added. Default is -1, so new axes are
+        added to the end.
+
+    Returns
+    -------
+    xn
+        `x` with extra dimensions added, if needed.
+    inv
+        Index tuple which inverses the operation.
+    """
+    # Desired dimensionality is already satisfied
+    if x.ndim >= N:
+        return x, (slice(None),) * x.ndim
+
+    # Create an indexer for the new axes
+    newdims = (np.newaxis,) * (N - x.ndim)
+
+    # Create an indexer to place the new axes
+    # according to `lax`
+    if lax == -1:
+        lax = x.ndim
+
+    slobj = (slice(None),) * max(x.ndim - lax, 0)
+
+    inv = np.s_[..., *(0 for _ in newdims), *slobj]
+
+    return x[..., *newdims, *slobj], inv
+
+
+def _check_shape(x: np.ndarray, A: np.ndarray, copy: bool = False):
+    """Set the last axis of `x` to match the first axis of `A`."""
+    sval = A.shape[0]
+
+    try:
+        si = x.shape.index(sval)
+    except ValueError as exc:
+        raise ValueError(f"Shape mismatch. x: {x.shape}, A: {A.shape}.") from exc
+
+    # Move the target axis to the end
+    if x.shape[-1] != sval:
+        x = np.moveaxis(x, si, -1)
+
+    # Make a copy. This is helpful for speed since
+    # the transposed array may not be c-contiguous,
+    # but should be used with caution if `x` is large
+    if copy:
+        x = x.copy(order="C")
+
+    return x, si
+
+
+def _dtype_to_real(dtype: np.dtype) -> np.dtype:
+    """Get a real dtype with matching precision."""
+    return np.dtype(dtype).type(0).real.dtype
+
+
+def _dtype_to_complex(dtype: np.dtype) -> np.dtype:
+    """Get a complex dtype with matching precision."""
+    _map = {
+        "float32": np.complex64,
+        "float64": np.complex128,
+    }
+
+    return np.dtype(_map[_dtype_to_real(dtype).name])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["readme", "version"]
 requires-python = ">=3.9"
 dependencies = [
     "caput @ git+https://github.com/radiocosmology/caput.git",
-    "caput[compression] @ git+https://github.com/radiocosmology/caput.git",
+    "caput[compression,fftw] @ git+https://github.com/radiocosmology/caput.git",
     "cora @ git+https://github.com/radiocosmology/cora.git",
     "cython>0.18",
     "driftscan @ git+https://github.com/radiocosmology/driftscan.git",


### PR DESCRIPTION
I want to look more into doing simultaneous frequency-ra interpolation, but this code is mostly complete and tested, so I think it's ready to be a PR.

This PR implements DPSS-based inpainting over a single axis, following the implementation in HERA's paper (https://arxiv.org/abs/2411.10529). It's been tested to work as-expected over both frequency and RA, with the caveat that it does not convert the RA axis to radians, which needs to be taken into account when selecting an appropriate cutoff. 

### util.dpss
Implements all the actual inpainting code. Only the diagonal of the final covariance is returned. 

### analysis.interpolate
Implements inpainting as a task. Includes a base task, which applies a constant cutoff over a single axis, and tasks which try to calculate a per-baseline foreground cutoff for frequency and ra. 

### analysis.delay
Implements a simple FFT delay transform using our current delay transform framework, with an optional argument to return the delay power spectrum instead. The power spectrum argument is also added to the Wiener filter delay transform code. I hope to eventually do another minor refactor of this module.

### analysis.transform
`analysis.delay.stokes_I` is moved here, with a slight modification to use the telescope polarisation property for improved readability. A standalone task to extract stokes I visibilities is also added, which was needed because, when inpainting, we want to inpaint _after_ computing stokes I. 