### PR TITLE
Tasks and containers for directional RFI mask

### DIFF
--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -2986,6 +2986,9 @@ def destripe(x, w, axis=1):
 class SiderealMaskConversion(task.SingleTask):
     """Convert the axis of an RFI mask from time to ra.
 
+    The conversion is performed by mapping values between Unix time and LSA
+    using the geographic location of the telescope, as provided by the Observer object.
+
     Attributes
     ----------
     spread_size : int

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -3112,7 +3112,7 @@ class ReduceMaskEl(task.SingleTask):
 
         Returns
         -------
-            out : containers.RFIMask(freq, time) or containers.SiderealRFIMask(freq, ra)
+        out : containers.RFIMask(freq, time) or containers.SiderealRFIMask(freq, ra)
             Non el-specific RFI mask indicating channels that are free from RFI events.
 
         """
@@ -3158,6 +3158,8 @@ class ApplyLocalizedRFIMask(task.SingleTask):
 
     This class extends the class ApplyTimeFreqMask to include el in addition to freq and ra,
     and can be further extended for a new RingMap class (freq,el,time).
+    Note that while the ra and el axes of the tstream and mask datasets do not need to be identical,
+    they must have overlapping regions. However, their freq axes must be identical.
 
     Attributes
     ----------

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -3024,7 +3024,7 @@ class SiderealMaskConversion(task.SingleTask):
 
         Returns
         -------
-            out : containers.LocalizedSiderealRFIMask
+        out : containers.LocalizedSiderealRFIMask
             Boolean mask that can be applied to a ringmap
             with the task `ApplyLocalizedRFIMask` to mask contaminated samples.
             Its axes are freq, ra, and el.

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -36,6 +36,8 @@ Containers
 - :py:class:`FormedBeamHA`
 - :py:class:`FormedBeamMask`
 - :py:class:`FormedBeamHAMask`
+- :py:class:`LocalizedRFIMask`
+- :py:class:`LocalizedSiderealRFIMask`
 
 Container Base Classes
 ----------------------
@@ -3340,3 +3342,87 @@ def copy_datasets_filter(
         if isinstance(dest_dset, memh5.MemDatasetDistributed):
             # Redistribute back to the original axis
             dest_dset.redistribute(original_ax_id)
+
+
+class LocalizedRFIMask(FreqContainer, TODContainer):
+    """Container for an RFI mask for each freq, el, and time sample.
+
+    The data frac_rfi stores information about the proportion of subdata
+    that detected RFI, which is used to generate the mask.
+    """
+
+    _axes = ("el",)
+
+    _dataset_spec: ClassVar = {
+        "mask": {
+            "axes": ["freq", "el", "time"],
+            "dtype": bool,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "frac_rfi": {
+            "axes": ["freq", "el", "time"],
+            "dtype": np.float32,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    @property
+    def mask(self):
+        """Get the mask dataset."""
+        return self.datasets["mask"]
+
+    @property
+    def frac_rfi(self):
+        """Get the frac_rfi dataset."""
+        return self.datasets["frac_rfi"]
+
+    @property
+    def el(self):
+        """Get the el axis."""
+        return self.index_map["el"]
+
+
+class LocalizedSiderealRFIMask(FreqContainer, SiderealContainer):
+    """Container for an RFI mask for each freq, ra, and el sample.
+
+    The data frac_rfi stores information about the proportion of subdata
+    that detected RFI, which is used to generate the mask.
+    """
+
+    _axes = ("el",)
+
+    _dataset_spec: ClassVar = {
+        "mask": {
+            "axes": ["freq", "ra", "el"],
+            "dtype": bool,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "frac_rfi": {
+            "axes": ["freq", "ra", "el"],
+            "dtype": np.float32,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+    }
+
+    @property
+    def mask(self):
+        """Get the mask dataset."""
+        return self.datasets["mask"]
+
+    @property
+    def frac_rfi(self):
+        """Get the frac_rfi dataset."""
+        return self.datasets["frac_rfi"]
+
+    @property
+    def el(self):
+        """Get the el axis."""
+        return self.index_map["el"]


### PR DESCRIPTION
The current RFI flagging allows only frequency and time/RA masks. I added two containers, **LocalizedRFIMask(freq, el, time)** and **LocalizedSiderealRFIMask(freq, el, ra)**, in core/containers.py, as well as three tasks, **SiderealMaskConversion**, **ReduceMaskEl**, and **ApplyLocalizedRFIMask**, in analysis/flagging.py, to enable elevation-specific directional RFI flagging in addition to freq and time/RA.