### PR TITLE
Speed up mmode and BeamformNS

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -210,6 +210,10 @@ class BeamformNS(task.SingleTask):
         Include autocorrelations in the calculation.  Default is False.
     save_dirty_beam : bool
         If True, computes and stores the dirty beam.  Default is False.
+    precision : int
+        Floating point precision to use when applying the beamforming
+        matrix. Using 32-bit precision results in a 2-3x reduction in
+        runtime, at the cost of potential numerical errors. Default is 64.
     """
 
     npix = config.Property(proptype=int, default=512)
@@ -218,6 +222,7 @@ class BeamformNS(task.SingleTask):
     scaled = config.Property(proptype=bool, default=False)
     include_auto = config.Property(proptype=bool, default=False)
     save_dirty_beam = config.Property(proptype=bool, default=False)
+    precision = config.enum([32, 64], default=64)
 
     def process(self, gstream):
         """Computes the ringmap.
@@ -280,8 +285,14 @@ class BeamformNS(task.SingleTask):
         hv.attrs["beamform_ns_freqmin"] = freq.min()
         hv.attrs["beamform_ns_nsmax"] = nsmax
 
+        # choose the precision which will be used in `matmul`
+        complex_dtype = np.dtype(f"complex{2*self.precision:.0f}")
+        real_dtype = np.dtype(f"float{self.precision:.0f}")
+
         # precompute a phase array
-        phase = 2.0 * np.pi * nspos[np.newaxis] * el[:, np.newaxis]
+        phase = (2.0 * np.pi * nspos[np.newaxis] * el[:, np.newaxis]).astype(
+            complex_dtype
+        )
 
         # Loop over local frequencies and fill ring map
         for lfi, fi in gstream.vis[:].enumerate(1):
@@ -303,7 +314,9 @@ class BeamformNS(task.SingleTask):
                 gw = gsr.astype(np.float32)
             else:
                 x = 0.5 * (vpos / vmax + 1)
-                ns_weight = tools.window_generalised(x, window=self.weight)
+                ns_weight = tools.window_generalised(x, window=self.weight).astype(
+                    real_dtype
+                )
                 gw = (gsw[:, lfi] > 0) * ns_weight[
                     np.newaxis, np.newaxis, :, np.newaxis
                 ]


### PR DESCRIPTION
There are a few critical improvements here:
## BeamformNS
- Use the `out` kwarg where possible to avoid unnecessary duplicate arrays
- Use a faster method to find masked baselines

## MModeTransform
- Use `.local_array` to avoid `mpiarray` read/writes
- Remove `for` loops during mmode transform and write
- Use fast `fftw` module for m transform
- Apply m-mode normalization when writing to the `mmode` array - this was surprisingly almost ⅓ of the function runtime