### PR TITLE
feat(ringmapmaker): ability to skip calculating the redundancy

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1165,8 +1165,12 @@ class RADependentWeights(task.SingleTask):
             )
             raise RuntimeError(msg)
 
+        # Ensure containers are distributed over the same axis
+        hybrid_vis.redistribute("freq")
+        ringmap.redistribute("freq")
+
         # Extract the variance of the hybrid visibilities from the weight dataset
-        var = tools.invert_no_zero(hybrid_vis.weight[:].view(np.ndarray))
+        var = tools.invert_no_zero(hybrid_vis.weight[:].local_array)
 
         # Calculate the time averaged variance
         var_time_avg = np.mean(var, axis=-1, keepdims=True)
@@ -1199,7 +1203,7 @@ class RADependentWeights(task.SingleTask):
         ) * tools.invert_no_zero(np.sum(weight_ew**2 * var, axis=-2))
 
         # Scale the ringmap weights by the RA dependence
-        ringmap.weight[:] *= ra_dependence[..., np.newaxis]
+        ringmap.weight[:].local_array[:] *= ra_dependence[..., np.newaxis]
 
         return ringmap
 

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -148,13 +148,13 @@ class MakeVisGrid(task.SingleTask):
         grid.redistribute("freq")
 
         # De-reference distributed arrays outside loop to save repeated MPI calls
-        ssv = sstream.vis[:]
-        ssw = sstream.weight[:]
+        ssv = sstream.vis[:].local_array
+        ssw = sstream.weight[:].local_array
 
-        gsv = grid.vis[:]
+        gsv = grid.vis[:].local_array
         gsv[:] = 0.0
 
-        gsw = grid.weight[:]
+        gsw = grid.weight[:].local_array
         gsw[:] = 0.0
 
         if self.save_redundancy:

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -167,7 +167,7 @@ class MakeVisGrid(task.SingleTask):
             gsv[p_ind, :, x_ind, ns_offset + y_ind, :] = ssv[:, vis_ind]
             gsw[p_ind, :, x_ind, ns_offset + y_ind, :] = ssw[:, vis_ind]
             if self.save_redundancy:
-                gsr[p_ind, x_ind, ns_offset - y_ind, :] = redundancy[vis_ind]
+                gsr[p_ind, x_ind, ns_offset + y_ind, :] = redundancy[vis_ind]
 
             if x_ind == 0:
                 pc_ind = pconjmap[p_ind]

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -29,6 +29,7 @@ from numpy.lib.recfunctions import structured_to_unstructured
 
 from ..core import containers, io, task
 from ..util import tools
+from ..util.exception import ConfigError
 from . import transform
 
 
@@ -235,6 +236,11 @@ class BeamformNS(task.SingleTask):
         gsv = gstream.vis[:].local_array
         gsw = gstream.weight[:].local_array
         if self.weight == "natural":
+            if "redundancy" not in gstream.datasets:
+                raise ConfigError(
+                    "Must set save_redundancy = True for task "
+                    "MakeVisGrid in order to use a natural weight scheme."
+                )
             gsr = gstream.redundancy[:]
 
         # Construct phase array

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1909,7 +1909,7 @@ class VisGridStream(FreqContainer, SiderealContainer, VisBase):
         "redundancy": {
             "axes": ["pol", "ew", "ns", "ra"],
             "dtype": np.int32,
-            "initialise": True,
+            "initialise": False,
             "distributed": False,
             "chunks": (1, 64, 1, 64, 128),
             "compression": COMPRESSION,
@@ -1920,7 +1920,10 @@ class VisGridStream(FreqContainer, SiderealContainer, VisBase):
     @property
     def redundancy(self):
         """Get the redundancy dataset."""
-        return self.datasets["redundancy"]
+        if "redundancy" in self.datasets:
+            return self.datasets["redundancy"]
+
+        raise KeyError("Dataset 'redundancy' not initialised.")
 
 
 class HybridVisStream(FreqContainer, SiderealContainer, VisBase):


### PR DESCRIPTION
Calculating the redundancy is computationally expensive and is only required if using a natural weighting scheme in `BeamformNS`.  This PR adds a config property `save_redundancy` to `MakeVisGrid` that when set to False will skip the calculation.

The PR also speeds up MakeVisGrid significantly by accessing local arrays outside of the for loop, preventing repeated MPIArray calls.  It fixes a longstanding bug in how redundancy was assigned that affected intracylinder baselines.  It also resolves some warnings related to MPIArray operations in RADependentWeights.