### PR TITLE
feat(ringmapmaker): create ReconstructVisWeight task

### DIFF
--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1228,15 +1228,15 @@ class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
 
         Parameters
         ----------
-        hv : HybridVisStream
+        hv : containers.HybridVisStream
             Hybrid beamformed visibilities with the desired weights.
 
         Returns
         -------
-        sstream : containers.SiderealStream
-            A sidereal stream whose visibilities are set to zero,
-            with weights  proportional to the baseline redundancy
-            and normalized to  reproduce the input weights after
+        ss : containers.SiderealStream
+            A sidereal stream with visibilities set to zero and
+            with weights proportional to the baseline redundancy
+            and normalized to reproduce the input weights after
             beamforming in the north-south direction.
         """
         # Extract parameters needed to calculate the window

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -19,6 +19,7 @@ Tasks
     WienerRingMapMakerAnalytical
     WienerRingMapMakerExternal
     RADependentWeights
+    ReconstructVisWeight
 """
 
 import numpy as np

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1219,7 +1219,7 @@ class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
 
     This is useful for generating noise realizations of hybrid beamformed
     visibilities that maintain proper correlation along the el axis.  It uses
-    the setup method defined in TelescopeStreamMixIn to create the the appropriate
+    the setup method defined in TelescopeStreamMixIn to create the appropriate
     prod, stack, and reverse_stack axis from a telescope instance.
     """
 

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1214,7 +1214,7 @@ class RADependentWeights(task.SingleTask):
         return ringmap
 
 
-class ReconstructVisWeights(transform.TelescopeStreamMixIn, task.SingleTask):
+class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
     """Compute visibility weights that match hybrid beamformed visibility weights.
 
     This is useful for generating noise realizations of hybrid beamformed

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -160,20 +160,7 @@ class CollateProducts(TelescopeStreamMixIn, task.SingleTask):
             'inverse_variance' - each baseline weighted by the weight attribute
     """
 
-    weight = config.Property(proptype=str, default="natural")
-
-    def setup(self, tel):
-        """Set the Telescope instance to use.
-
-        Parameters
-        ----------
-        tel : TransitTelescope
-            Telescope object to use
-        """
-        if self.weight not in ["natural", "uniform", "inverse_variance"]:
-            raise KeyError(f"Do not recognize weight = {self.weight!s}")
-
-        super().setup(tel)
+    weight = config.enum(["natural", "uniform", "inverse_variance"], default="natural")
 
     @overload
     def process(self, ss: containers.SiderealStream) -> containers.SiderealStream: ...


### PR DESCRIPTION
Generates visibility weights that will match hybrid beamformed
visibility weights after beamforming north-south.  Useful for
generating noise realizations of hybrid beamformed visibilities
that maintain proper correlation along the el axis.