### PR TITLE
Bump Python 3.10-3.13 and include astropy dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Install apt dependencies
       run: |
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.12]
+        python-version: ["3.10", "3.13"]
 
     runs-on: ubuntu-latest
     steps:
@@ -82,10 +82,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install apt dependencies
         run: |

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -1,6 +1,6 @@
 """Delay space spectrum estimation and filtering."""
 
-from typing import Optional, TypeVar, Union
+from typing import TypeVar
 
 import numpy as np
 import scipy.linalg as la
@@ -512,7 +512,7 @@ class DelayTransformBase(task.SingleTask):
         raise NotImplementedError()
 
     def _calculate_delays(
-        self, ss: Union[FreqContainer, list[FreqContainer]]
+        self, ss: FreqContainer | list[FreqContainer]
     ) -> tuple[np.ndarray, np.ndarray]:
         """Calculate the grid of delays.
 
@@ -570,7 +570,7 @@ class DelayTransformBase(task.SingleTask):
         self,
         data: np.ndarray,
         weight: np.ndarray,
-    ) -> Optional[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None:
         """Apply cuts on the data and weights and returned modified versions.
 
         Parameters
@@ -677,7 +677,7 @@ class DelayGibbsSamplerBase(DelayTransformBase, random.RandomTask):
         self,
         ss: FreqContainer,
         delays: np.ndarray,
-        coord_axes: Union[list[str], np.ndarray],
+        coord_axes: list[str] | np.ndarray,
     ) -> ContainerBase:
         """Create the output container for the delay power spectrum.
 
@@ -1482,7 +1482,7 @@ def fourier_matrix_c2c(N, fsel=None):
     return F
 
 
-def fourier_matrix(N: int, fsel: Optional[np.ndarray] = None) -> np.ndarray:
+def fourier_matrix(N: int, fsel: np.ndarray | None = None) -> np.ndarray:
     """Generate a Fourier matrix to represent a real to complex FFT.
 
     Parameters
@@ -1769,9 +1769,9 @@ def delay_spectrum_gibbs_cross(
     Ni: np.ndarray,
     initial_S: np.ndarray,
     window: str = "nuttall",
-    fsel: Optional[np.ndarray] = None,
+    fsel: np.ndarray | None = None,
     niter: int = 20,
-    rng: Optional[np.random.Generator] = None,
+    rng: np.random.Generator | None = None,
 ) -> list[np.ndarray]:
     """Estimate the delay power spectrum by Gibbs sampling.
 
@@ -2143,7 +2143,7 @@ def match_axes(dset1, dset2):
 def flatten_axes(
     dset: memh5.MemDatasetDistributed,
     axes_to_keep: list[str],
-    match_dset: Optional[memh5.MemDatasetDistributed] = None,
+    match_dset: memh5.MemDatasetDistributed | None = None,
 ) -> tuple[mpiarray.MPIArray, list[str]]:
     """Move the specified axes of the dataset to the back, and flatten all others.
 

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -8,7 +8,7 @@ be excluded and `False` for clean samples.
 """
 
 import warnings
-from typing import Union, overload
+from typing import overload
 
 import numpy as np
 from caput import config, mpiarray, weighted_median
@@ -809,7 +809,7 @@ class ThresholdVisWeightBaseline(task.SingleTask):
     def process(
         self,
         stream,
-    ) -> Union[containers.BaselineMask, containers.SiderealBaselineMask]:
+    ) -> containers.BaselineMask | containers.SiderealBaselineMask:
         """Construct baseline-dependent mask.
 
         Parameters
@@ -913,8 +913,8 @@ class CollapseBaselineMask(task.SingleTask):
 
     def process(
         self,
-        baseline_mask: Union[containers.BaselineMask, containers.SiderealBaselineMask],
-    ) -> Union[containers.RFIMask, containers.SiderealRFIMask]:
+        baseline_mask: containers.BaselineMask | containers.SiderealBaselineMask,
+    ) -> containers.RFIMask | containers.SiderealRFIMask:
         """Collapse input mask over baseline axis.
 
         Parameters
@@ -2038,8 +2038,8 @@ class RFIMask(task.SingleTask):
     def process(self, sstream: containers.TimeStream) -> containers.RFIMask: ...
 
     def process(
-        self, sstream: Union[containers.TimeStream, containers.SiderealStream]
-    ) -> Union[containers.RFIMask, containers.SiderealRFIMask]:
+        self, sstream: containers.TimeStream | containers.SiderealStream
+    ) -> containers.RFIMask | containers.SiderealRFIMask:
         """Apply a day time mask.
 
         Parameters
@@ -2156,7 +2156,7 @@ class ApplyTimeFreqMask(task.SingleTask):
         tstream : timestream or sidereal stream
             The masked timestream. Note that the masking is done in place.
         """
-        if isinstance(rfimask, (containers.RFIMask, containers.RFIMaskByPol)):
+        if isinstance(rfimask, containers.RFIMask | containers.RFIMaskByPol):
             if not hasattr(tstream, "time"):
                 raise TypeError(
                     f"Expected a timestream like type. Got {type(tstream)}."
@@ -2166,7 +2166,7 @@ class ApplyTimeFreqMask(task.SingleTask):
                 raise ValueError("timestream and mask data have different time axes.")
 
         elif isinstance(
-            rfimask, (containers.SiderealRFIMask, containers.SiderealRFIMaskByPol)
+            rfimask, containers.SiderealRFIMask | containers.SiderealRFIMaskByPol
         ):
             if not hasattr(tstream, "ra"):
                 raise TypeError(
@@ -2196,7 +2196,7 @@ class ApplyTimeFreqMask(task.SingleTask):
 
         # Deal with the polarisation axis
         if isinstance(
-            rfimask, (containers.RFIMaskByPol, containers.SiderealRFIMaskByPol)
+            rfimask, containers.RFIMaskByPol | containers.SiderealRFIMaskByPol
         ):
 
             if self.collapse_pol or "pol" not in t_axes:
@@ -2465,8 +2465,8 @@ class MaskFreq(task.SingleTask):
     freq_frac = config.Property(proptype=float, default=None)
 
     def process(
-        self, data: Union[containers.VisContainer, containers.RingMap]
-    ) -> Union[containers.RFIMask, containers.SiderealRFIMask]:
+        self, data: containers.VisContainer | containers.RingMap
+    ) -> containers.RFIMask | containers.SiderealRFIMask:
         """Make the mask.
 
         Parameters
@@ -2545,7 +2545,7 @@ class MaskFreq(task.SingleTask):
             if isinstance(s, int):
                 if s < nfreq:
                     mask[s] = True
-            elif isinstance(s, (tuple, list)) and len(s) == 2:
+            elif isinstance(s, tuple | list) and len(s) == 2:
                 mask[s[0] : s[1]] = True
             else:
                 raise ValueError(

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -3,7 +3,7 @@
 This includes grouping frequencies and products to performing the m-mode transform.
 """
 
-from typing import Optional, Union, overload
+from typing import overload
 
 import numpy as np
 import scipy.linalg as la
@@ -550,7 +550,7 @@ class MModeTransform(task.SingleTask):
 
     remove_integration_window = config.Property(proptype=bool, default=False)
 
-    def setup(self, manager: Optional[io.TelescopeConvertible] = None):
+    def setup(self, manager: io.TelescopeConvertible | None = None):
         """Set the telescope instance if a manager object is given.
 
         This is used to set the `mmax` used in the transform.
@@ -1421,7 +1421,7 @@ class MixData(task.SingleTask):
         self._tags = []
         self._wfunc = tools.invert_no_zero if self.invert_weight else lambda x: x
 
-    def process(self, data: Union[containers.SiderealStream, containers.RingMap]):
+    def process(self, data: containers.SiderealStream | containers.RingMap):
         """Add the input data into the mixed data output.
 
         Parameters
@@ -1488,7 +1488,7 @@ class MixData(task.SingleTask):
 
         self._data_ind += 1
 
-    def process_finish(self) -> Union[containers.SiderealStream, containers.RingMap]:
+    def process_finish(self) -> containers.SiderealStream | containers.RingMap:
         """Return the container with the mixed inputs.
 
         Returns

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -60,7 +60,7 @@ their own custom container types.
 """
 
 import inspect
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 import numpy as np
 from caput import memh5, mpiarray, tod
@@ -201,7 +201,7 @@ class ContainerBase(memh5.BasicCont):
                 copy_axis_attrs = False
 
                 # If axis is an integer, turn into an arange as a default definition
-                if isinstance(axis_map, (int, np.integer)):
+                if isinstance(axis_map, int | np.integer):
                     axis_map = np.arange(axis_map)
 
             # If no valid map provided in arguments copy from another object if set
@@ -643,8 +643,8 @@ class DataWeightContainer(ContainerBase):
     `_weight_dset_name`.
     """
 
-    _data_dset_name: Optional[str] = None
-    _weight_dset_name: Optional[str] = None
+    _data_dset_name: str | None = None
+    _weight_dset_name: str | None = None
 
     @property
     def data(self) -> memh5.MemDataset:
@@ -1023,7 +1023,7 @@ class MContainer(ContainerBase):
     _axes = ("m", "msign")
 
     def __init__(
-        self, mmax: Optional[int] = None, oddra: Optional[bool] = None, *args, **kwargs
+        self, mmax: int | None = None, oddra: bool | None = None, *args, **kwargs
     ):
         # Set up axes from passed arguments
         if mmax is not None:
@@ -2260,7 +2260,7 @@ class GainDataBase(DataWeightContainer):
         return self.datasets["gain"]
 
     @property
-    def weight(self) -> Optional[memh5.MemDataset]:
+    def weight(self) -> memh5.MemDataset | None:
         """The weights for each data point.
 
         Returns None is no weight dataset exists.
@@ -3216,9 +3216,9 @@ def empty_timestream(**kwargs):
 def copy_datasets_filter(
     source: ContainerBase,
     dest: ContainerBase,
-    axis: Union[str, list, tuple] = [],
-    selection: Union[np.ndarray, list, slice, dict] = {},
-    exclude_axes: Optional[list[str]] = None,
+    axis: str | list | tuple = [],
+    selection: np.ndarray | list | slice | dict = {},
+    exclude_axes: list[str] | None = None,
     copy_without_selection: bool = False,
 ):
     """Copy datasets while filtering a given axis.

--- a/draco/core/io.py
+++ b/draco/core/io.py
@@ -27,7 +27,7 @@ import os.path
 import shutil
 import subprocess
 from functools import partial
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 import numpy as np
 from caput import config, fileformats, memh5, pipeline, truncate
@@ -39,7 +39,7 @@ from ..util.exception import ConfigError
 from . import task
 
 
-def _list_of_filelists(files: Union[list[str], list[list[str]]]) -> list[list[str]]:
+def _list_of_filelists(files: list[str] | list[list[str]]) -> list[list[str]]:
     """Take in a list of lists/glob patterns of filenames.
 
     Parameters
@@ -77,7 +77,7 @@ def _list_of_filelists(files: Union[list[str], list[list[str]]]) -> list[list[st
     return f2
 
 
-def _list_or_glob(files: Union[str, list[str]]) -> list[str]:
+def _list_or_glob(files: str | list[str]) -> list[str]:
     """Take in a list of lists/glob patterns of filenames.
 
     Parameters
@@ -126,7 +126,7 @@ def _list_or_glob(files: Union[str, list[str]]) -> list[str]:
     )
 
 
-def _list_of_filegroups(groups: Union[list[dict], dict]) -> list[dict]:
+def _list_of_filegroups(groups: list[dict] | dict) -> list[dict]:
     """Process a file group/groups.
 
     Parameters
@@ -426,7 +426,7 @@ class SelectionsMixin:
     def _parse_range(self, x):
         # Parse and validate a range type selection
 
-        if not isinstance(x, (list, tuple)) or len(x) > 3 or len(x) < 2:
+        if not isinstance(x, list | tuple) or len(x) > 3 or len(x) < 2:
             raise ValueError(
                 f"Range spec must be a length 2 or 3 list or tuple. Got {x}."
             )
@@ -440,7 +440,7 @@ class SelectionsMixin:
     def _parse_index(self, x, type_=object):
         # Parse and validate an index type selection
 
-        if not isinstance(x, (list, tuple)) or len(x) == 0:
+        if not isinstance(x, list | tuple) or len(x) == 0:
             raise ValueError(f"Index spec must be a non-empty list or tuple. Got {x}.")
 
         for v in x:
@@ -690,7 +690,7 @@ class FindFiles(pipeline.TaskBase):
 
     def setup(self):
         """Return list of files specified in the parameters."""
-        if not isinstance(self.files, (list, tuple)):
+        if not isinstance(self.files, list | tuple):
             raise RuntimeError("Argument must be list of files.")
 
         return self.files
@@ -715,7 +715,7 @@ class LoadFiles(LoadFilesFromParams):
         # Call the baseclass setup to resolve any selections
         super().setup()
 
-        if not isinstance(files, (list, tuple)):
+        if not isinstance(files, list | tuple):
             raise RuntimeError(f'Argument must be list of files. Got "{files}"')
 
         self.files = files
@@ -1149,7 +1149,7 @@ class ZipZarrContainers(task.SingleTask):
 class ZarrZipHandle:
     """A handle for keeping track of background Zarr-zipping job."""
 
-    def __init__(self, filename: str, handle: Optional[subprocess.Popen]):
+    def __init__(self, filename: str, handle: subprocess.Popen | None):
         self.filename = filename
         self.handle = handle
 
@@ -1232,7 +1232,7 @@ class SaveZarrZip(ZipZarrContainers):
 class WaitZarrZip(task.MPILoggedTask):
     """Collect Zarr-zipping jobs and wait for them to complete."""
 
-    _handles: Optional[list[ZarrZipHandle]] = None
+    _handles: list[ZarrZipHandle] | None = None
 
     def next(self, handle: ZarrZipHandle):
         """Receive the handles to wait on.
@@ -1324,8 +1324,8 @@ class SaveConfig(task.SingleTask):
 
 
 # Python types for objects convertible to beamtransfers or telescope instances
-BeamTransferConvertible = Union[manager.ProductManager, beamtransfer.BeamTransfer]
-TelescopeConvertible = Union[BeamTransferConvertible, telescope.TransitTelescope]
+BeamTransferConvertible = manager.ProductManager | beamtransfer.BeamTransfer
+TelescopeConvertible = BeamTransferConvertible | telescope.TransitTelescope
 
 
 def get_telescope(obj):

--- a/draco/core/misc.py
+++ b/draco/core/misc.py
@@ -51,7 +51,7 @@ class ApplyGain(task.SingleTask):
         gain.redistribute("freq")
 
         if tstream.is_stacked and not isinstance(
-            gain, (containers.CommonModeGainData, containers.CommonModeSiderealGainData)
+            gain, containers.CommonModeGainData | containers.CommonModeSiderealGainData
         ):
             raise ValueError(
                 f"Cannot apply input-dependent gains to stacked data: {tstream!s}"
@@ -68,12 +68,10 @@ class ApplyGain(task.SingleTask):
 
         elif isinstance(
             gain,
-            (
-                containers.GainData,
-                containers.SiderealGainData,
-                containers.CommonModeGainData,
-                containers.CommonModeSiderealGainData,
-            ),
+            containers.GainData
+            | containers.SiderealGainData
+            | containers.CommonModeGainData
+            | containers.CommonModeSiderealGainData,
         ):
             # Extract gain array
             gain_arr = gain.gain[:]
@@ -86,7 +84,7 @@ class ApplyGain(task.SingleTask):
 
             if isinstance(
                 gain,
-                (containers.SiderealGainData, containers.CommonModeSiderealGainData),
+                containers.SiderealGainData | containers.CommonModeSiderealGainData,
             ):
                 # Check that we are defined at the same RA samples
                 if (gain.ra != tstream.ra).any():
@@ -151,7 +149,7 @@ class ApplyGain(task.SingleTask):
                 tstream.vis[:], gvis, out=tstream.vis[:], prod_map=tstream.prod
             )
         elif isinstance(
-            gain, (containers.CommonModeGainData, containers.CommonModeSiderealGainData)
+            gain, containers.CommonModeGainData | containers.CommonModeSiderealGainData
         ):
             # Apply the gains to all 'prods/stacks' directly:
             tstream.vis[:] *= np.abs(gvis[:, np.newaxis, :]) ** 2
@@ -174,7 +172,7 @@ class ApplyGain(task.SingleTask):
                 tstream.weight[:], gweight, out=tstream.weight[:], prod_map=tstream.prod
             )
         elif isinstance(
-            gain, (containers.CommonModeGainData, containers.CommonModeSiderealGainData)
+            gain, containers.CommonModeGainData | containers.CommonModeSiderealGainData
         ):
             # Apply the gains to all 'prods/stacks' directly:
             tstream.weight[:] *= gweight[:, np.newaxis, :] ** 2

--- a/draco/core/task.py
+++ b/draco/core/task.py
@@ -3,7 +3,6 @@
 import logging
 import os
 from inspect import getfullargspec
-from typing import Optional
 
 import numpy as np
 from caput import config, fileformats, memh5, pipeline
@@ -450,7 +449,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
 
         return output
 
-    def _save_output(self, output: memh5.MemDiskGroup, ii: int = 0) -> Optional[str]:
+    def _save_output(self, output: memh5.MemDiskGroup, ii: int = 0) -> str | None:
         """Save the output and return the file path if it was saved."""
         if output is None:
             return None
@@ -625,7 +624,7 @@ class SingleTask(MPILoggedTask, pipeline.BasicContMixin):
                         found = True
                         break
 
-            elif isinstance(n, (memh5.MemGroup, memh5.MemDiskGroup)):
+            elif isinstance(n, memh5.MemGroup | memh5.MemDiskGroup):
                 for item in n.values():
                     stack.append(item)
 

--- a/draco/util/random.py
+++ b/draco/util/random.py
@@ -4,7 +4,8 @@ import concurrent.futures
 import contextlib
 import os
 import zlib
-from typing import Callable, ClassVar, Optional
+from collections.abc import Callable
+from typing import ClassVar
 
 import numpy as np
 from caput import config
@@ -299,9 +300,9 @@ class MultithreadedRNG(np.random.Generator):
 
     def __init__(
         self,
-        seed: Optional[int] = None,
-        threads: Optional[int] = None,
-        bitgen: Optional[np.random.BitGenerator] = None,
+        seed: int | None = None,
+        threads: int | None = None,
+        bitgen: np.random.BitGenerator | None = None,
     ):
         if bitgen is None:
             bitgen = _default_bitgen

--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -4,8 +4,6 @@ This is described in some detail in `doclib:173
 <http://bao.chimenet.ca/doc/cgi-bin/general/documents/display?Id=173>`_.
 """
 
-from typing import Union
-
 import numpy as np
 import scipy.linalg as la
 import scipy.sparse as ss
@@ -215,7 +213,7 @@ def rebin_matrix(tra: np.ndarray, ra: np.ndarray, width_t: float = 0) -> np.ndar
 
 
 def grad_1d(
-    x: np.ndarray, si: np.ndarray, mask: np.ndarray, period: Union[float, None] = None
+    x: np.ndarray, si: np.ndarray, mask: np.ndarray, period: float | None = None
 ) -> np.ndarray:
     """Gradient with boundary samples wrapped.
 
@@ -279,8 +277,8 @@ def taylor_coeff(
     M: int,
     Ni: np.ndarray,
     Si: float,
-    period: Union[float, None] = None,
-    xc: Union[np.ndarray, None] = None,
+    period: float | None = None,
+    xc: np.ndarray | None = None,
 ) -> list[ss.csr_array]:
     """Return a set of sparse matrices that estimates expansion coefficients.
 

--- a/draco/util/testing.py
+++ b/draco/util/testing.py
@@ -1,7 +1,5 @@
 """draco test utils."""
 
-from typing import Optional, Union
-
 import numpy as np
 from caput import config, memh5, pipeline
 
@@ -50,10 +48,10 @@ def mock_freq_data(
     freq: np.ndarray,
     ntime: int,
     delaycut: float,
-    ndata: Optional[int] = None,
+    ndata: int | None = None,
     noise: float = 0.0,
-    bad_freq: Optional[np.ndarray] = None,
-    rng: Optional[np.random.Generator] = None,
+    bad_freq: np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Make mock delay data with a constant delay spectrum up to a specified cut.
 
@@ -150,7 +148,7 @@ class RandomFreqData(random.RandomTask):
     delay_cut = config.Property(proptype=float, default=0.2)
     noise = config.Property(proptype=float, default=1e-5)
 
-    def next(self) -> Union[SiderealStream, list[SiderealStream]]:
+    def next(self) -> SiderealStream | list[SiderealStream]:
         """Generate correlated sidereal streams.
 
         Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
     { name = "Don Wiebe", email = "dvw@phas.ubc.ca" }
 ]
 dynamic = ["readme", "version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "caput @ git+https://github.com/radiocosmology/caput.git",
     "caput[compression,fftw] @ git+https://github.com/radiocosmology/caput.git",
@@ -30,7 +30,7 @@ dependencies = [
     "mpi4py",
     "numpy>=1.24",
     "scikit-image",
-    "scipy>=0.10",
+    "scipy>=1.14",
     "skyfield",
     "pywavelets",
 ]
@@ -108,4 +108,4 @@ exclude = [
     "*/__init__.py",
 ]
 
-target-version = "py39"
+target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "driftscan @ git+https://github.com/radiocosmology/driftscan.git",
     "mpi4py",
     "numpy>=1.24",
+    "astropy>=6.1.6",
     "scikit-image",
     "scipy>=1.14",
     "skyfield",


### PR DESCRIPTION
The minimum pinned version is based on fixes related to numpy 2 vs numpy 1 behaviour. Since we want to support numpy 2, we should use this minimum version. 


Also, there's an `astropy` import somewhere in `draco`, but it isn't included in the dependencies.