### PR TITLE
fix(null_delay_filter): Fix ptp() call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Editor rubble
+*~
+.*.sw?

--- a/draco/analysis/delay.py
+++ b/draco/analysis/delay.py
@@ -2082,7 +2082,7 @@ def null_delay_filter(
         raise ValueError(f"Filter type must be one of [high, low]. Got {type_}")
 
     # Construct the window function
-    x = (freq - freq.min()) / freq.ptp()
+    x = (freq - freq.min()) / np.ptp(freq)
     w = tools.window_generalised(x, window="nuttall")
 
     delay = np.linspace(-delay_cut, delay_cut, num_delay)


### PR DESCRIPTION
Yukari noticed this was crashing.

Numpy-2.0 removed the `ptp` method from `ndarray`.