### PR TITLE
Fix baseline ordering error in RFI mask

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1177,9 +1177,9 @@ def stokes_I(sstream, tel):
 
     Returns
     -------
-    vis_I : mpiarray.MPIArray[nbase, nfreq, ntime]
+    vis_I : mpiarray.MPIArray[nfreq, nbase, ntime]
         The instrumental Stokes I visibilities, distributed over baselines.
-    vis_weight : mpiarray.MPIArray[nbase, nfreq, ntime]
+    vis_weight : mpiarray.MPIArray[nfreq, nbase, ntime]
         The weights for each visibility, distributed over baselines.
     ubase : np.ndarray[nbase, 2]
         Baseline vectors corresponding to output.
@@ -1211,8 +1211,8 @@ def stokes_I(sstream, tel):
     is_copol = pols[:, 0] == pols[:, 1]
 
     # Iterate over products to construct the Stokes I vis
-    ssv = sstream.vis[:]
-    ssw = sstream.weight[:]
+    ssv = sstream.vis[:].local_array
+    ssw = sstream.weight[:].local_array
 
     for ii, ui in enumerate(uinv):
         # Skip if not a co-pol baseline

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1228,8 +1228,8 @@ def stokes_I(sstream, tel):
             continue
 
         # Accumulate the visibilities and weights
-        vis_I[:, ui] += ssv[:, ii]
-        vis_weight[:, ui] += ssw[:, ii]
+        vis_I.local_array[:, ui] += ssv[:, ii]
+        vis_weight.local_array[:, ui] += ssw[:, ii]
 
     return vis_I, vis_weight, ubase
 


### PR DESCRIPTION
In #318, the `stokes_I` function was changed to maintain the standard visibility axis order. This task, which make use of that function, was never updated to accommodate this change.

I think that this is the only other place where this function is used.