### PR TITLE
fix(beamform, mockcatalog): remove deprecated `healpy` verbose keyword

### DIFF
--- a/draco/analysis/beamform.py
+++ b/draco/analysis/beamform.py
@@ -1598,7 +1598,8 @@ class HealpixBeamForm(task.SingleTask):
         for lfi, _ in mv.enumerate(axis=0):
             for pi in range(mv.shape[1]):
                 mv[lfi, pi] = healpy.smoothing(
-                    mv[lfi, pi], fwhm=np.radians(self.fwhm), verbose=False
+                    mv[lfi, pi],
+                    fwhm=np.radians(self.fwhm),
                 )
 
     def process(self, catalog: containers.SourceCatalog) -> containers.FormedBeam:

--- a/draco/synthesis/mockcatalog.py
+++ b/draco/synthesis/mockcatalog.py
@@ -302,7 +302,8 @@ class ResizeSelectionFunctionMap(task.SingleTask):
                 old_nside = selfunc.nside
                 smoothing_fwhm = hp.nside2resol(old_nside)
                 new_selfunc_map_local[:][fi, 0] = hp.smoothing(
-                    new_selfunc_map_local[:][fi, 0], fwhm=smoothing_fwhm, verbose=False
+                    new_selfunc_map_local[:][fi, 0],
+                    fwhm=smoothing_fwhm,
                 )
 
             new_selfunc_map_local[:][fi, 0][new_selfunc_map_local[:][fi, 0][:] < 0] = 0


### PR DESCRIPTION
`verbose` keywords have been deprecated since `healpy 1.15.0`