### PR TITLE
feat(flagging): refactor mask logic, add taper support

### DIFF
--- a/draco/analysis/beamform.py
+++ b/draco/analysis/beamform.py
@@ -1522,16 +1522,6 @@ class FitBeamFormed(BeamFormExternalMixin, task.SingleTask):
                     XT * (w * b)[..., np.newaxis, :], axis=-1, keepdims=True
                 )
 
-                self.log.info(
-                    f"proj_wb: {proj_wb.shape} "
-                    f"XT: {XT.shape} "
-                    f"X: {X.shape} "
-                    f"w: {w.shape} "
-                    f"b: {b.shape} "
-                    f"A: {A.shape} "
-                    f"sigma: {sigma.shape}"
-                )
-
                 coeff = np.linalg.solve(A, proj_wb)[..., 0]
                 cov = np.linalg.solve(A, np.eye(2))
 

--- a/draco/analysis/beamform.py
+++ b/draco/analysis/beamform.py
@@ -1518,8 +1518,21 @@ class FitBeamFormed(BeamFormExternalMixin, task.SingleTask):
                 A = np.matmul(XT, w[..., np.newaxis] * X) + np.eye(2) * self.epsilon
 
                 # Solve for the parameters and their covariance
-                proj_wb = np.sum(XT * (w * b)[..., np.newaxis, :], axis=-1)
-                coeff = np.linalg.solve(A, proj_wb)
+                proj_wb = np.sum(
+                    XT * (w * b)[..., np.newaxis, :], axis=-1, keepdims=True
+                )
+
+                self.log.info(
+                    f"proj_wb: {proj_wb.shape} "
+                    f"XT: {XT.shape} "
+                    f"X: {X.shape} "
+                    f"w: {w.shape} "
+                    f"b: {b.shape} "
+                    f"A: {A.shape} "
+                    f"sigma: {sigma.shape}"
+                )
+
+                coeff = np.linalg.solve(A, proj_wb)[..., 0]
                 cov = np.linalg.solve(A, np.eye(2))
 
                 # Save to output container
@@ -1598,8 +1611,7 @@ class HealpixBeamForm(task.SingleTask):
         for lfi, _ in mv.enumerate(axis=0):
             for pi in range(mv.shape[1]):
                 mv[lfi, pi] = healpy.smoothing(
-                    mv[lfi, pi],
-                    fwhm=np.radians(self.fwhm),
+                    mv[lfi, pi], fwhm=np.radians(self.fwhm), verbose=False
                 )
 
     def process(self, catalog: containers.SourceCatalog) -> containers.FormedBeam:

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -458,9 +458,11 @@ class DayenuDelayFilterHybridVis(task.SingleTask):
         # Create a filter dataset
         if self.save_filter:
             if np.any(np.abs(self.tauc) > 0.0):
-                stream.add_dataset("complex_filter")
+                if "complex_filter" not in stream.datasets:
+                    stream.add_dataset("complex_filter")
             else:
-                stream.add_dataset("filter")
+                if "filter" not in stream.datasets:
+                    stream.add_dataset("filter")
             stream.filter[:] = 0.0
 
         if not self.apply_filter:

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -2530,7 +2530,7 @@ class GeneralCombineTapers(GeneralCombineMasks):
     """
 
     _dataset_name = "taper"
-    _operators: ClassVar[set[str]] = set("+-*/")
+    _operators: ClassVar[set[str]] = set("+-*/()")
 
 
 class CombineTapers(GeneralCombineTapers):

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -2375,6 +2375,9 @@ class GeneralCombineMasks(task.SingleTask):
         if any(type(mask) is not type(masks[0]) for mask in masks[1:]):
             raise TypeError("All input masks must be of the same container type.")
 
+        for mask in masks:
+            mask.redistribute("freq")
+
         # Assign variables A, B, C, ..., one per mask
         namespace = {
             chr(ord("A") + i): mask.datasets[self._dataset_name][:]
@@ -2387,7 +2390,8 @@ class GeneralCombineMasks(task.SingleTask):
 
         # Create a copy and set the result
         combined_mask = masks[0].copy()
-        combined_mask.mask[:] = result
+        combined_mask.redistribute("freq")
+        combined_mask.datasets[self._dataset_name][:] = result
 
         return combined_mask
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2266,6 +2266,11 @@ class RingMapTaper(FreqContainer, SiderealContainer):
         """Get the mask dataset."""
         return self.datasets["taper"]
 
+    @property
+    def weight(self):
+        """Map weight to taper so that it can easily be updated with masks."""
+        return self.datasets["taper"]
+
 
 class GainDataBase(DataWeightContainer):
     """A container interface for gain-like data.


### PR DESCRIPTION
* Replace CombineMasks with a GeneralCombineMasks task that can construct
arbitrary combinations of masks.
* Create ApplyTaper task, which applies a taper to a RingMap.
* Introduce GeneralCombineTapers task for arbitrary taper combination.
* Add MaskFromTaper task to generate binary masks from taper thresholds.
* Define new container RingMapTaper and HorizonLimit container.
* Do not create datasets if they already exist in DayenuDelayFilterHybridVis.
* Fix bug in FitBeamForm.