### PR TITLE
feat: track freq-freq covariance matrix

### DIFF
--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -423,6 +423,8 @@ class DayenuDelayFilterHybridVis(task.SingleTask):
     apply_filter : bool
         Apply the filter that was generated. If False, `save_filter`
         must be True.
+    save_filter : bool
+        Save the filter that was applied to the output container.
     calculate_cov : bool
         Calculate the frequency-frequency noise covariance due to filtering.
     """

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -643,10 +643,10 @@ class ApplyDelayFilterHybridVis(task.SingleTask):
         # Create the covariance dataset if requested
         if self.calculate_cov:
             if np.iscomplexobj(source.filter[:].local_array):
-                if "complex_cov" not in hv.datasets:
+                if "complex_freq_cov" not in hv.datasets:
                     hv.add_dataset("complex_freq_cov")
             else:
-                if "cov" not in hv.datasets:
+                if "freq_cov" not in hv.datasets:
                     hv.add_dataset("freq_cov")
             hv.freq_cov[:] = 0.0
 

--- a/draco/analysis/powerspec.py
+++ b/draco/analysis/powerspec.py
@@ -200,7 +200,7 @@ class WienerDelayTransformMap(task.SingleTask):
             # Loop over elevations
             for ee in range(nel_local):
 
-                # Maps for this frequency and polarisation
+                # Extract maps for this polarisation and elevation
                 # Shape (ra, freq)
                 d = dall[pp, :, :, ee].T
                 w = wall[pp, :, :, ee].T
@@ -231,7 +231,7 @@ class WienerDelayTransformMap(task.SingleTask):
                 # Shape (freq, freq)
                 FSFT = s.T @ s / nra
 
-                # Signal covariance in filtered frequency domain
+                # Signal covariance in masked, filtered frequency domain
                 # Shape (ra, freq, freq)
                 RSRT = H @ FSFT @ HT
 
@@ -239,7 +239,7 @@ class WienerDelayTransformMap(task.SingleTask):
                 # Shape (delay, delay)
                 S = FT @ FSFT @ F
 
-                # Covariance (signal + noise) in filtered frequency domain
+                # Covariance (signal + noise) in masked, filtered frequency domain
                 # Shape (ra, freq, freq)
                 A = RSRT + N
 

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -773,13 +773,13 @@ class DeconvolveHybridMBase(task.SingleTask):
 
             # Fill in the dirty beam
             dirty_beam_ra = (
-                np.fft.irfft(
-                        dirty_beam_m.transpose(1, 2, 0), axis=-1, n=nra
-                    ).transpose(0, 2, 1)
-                    * norm
+                np.fft.irfft(dirty_beam_m.transpose(1, 2, 0), axis=-1, n=nra).transpose(
+                    0, 2, 1
                 )
+                * norm
+            )
 
-            rmbp[0, :, lfi] = np.sum(dirty_beam_ra ** 2, axis=1) / nra
+            rmbp[0, :, lfi] = np.sum(dirty_beam_ra**2, axis=1) / nra
 
             if self.save_dirty_beam:
                 rmb[0, :, lfi] = dirty_beam_ra
@@ -1294,13 +1294,19 @@ class RADependentWeights(task.SingleTask):
         return ringmap
 
 
-class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
-    """Compute visibility weights that match hybrid beamformed visibility weights.
+class ReconstructVisNoiseBase(transform.TelescopeStreamMixIn, task.SingleTask):
+    """Reconstruct visibility weights or covariances consistent with hybrid beamforming.
 
-    This is useful for generating noise realizations of hybrid beamformed
-    visibilities that maintain proper correlation along the el axis.  It uses
-    the setup method defined in TelescopeStreamMixIn to create the appropriate
-    prod, stack, and reverse_stack axis from a telescope instance.
+    This class provides shared logic for reproducing the statistical properties of
+    hybrid beamformed visibilities, such as their weight structure or
+    frequency-frequency covariance. It computes the layout of baselines, builds
+    beamforming window functions, and parses beamforming attributes from
+    input containers.
+
+    This class is abstract and requires subclasses to implement `_redistribute_input`
+    and `_fill_output` methods.  These determine how the input container is
+    redistributed (e.g., over RA or frequency) and how the output container is
+    constructed and populated (e.g., SiderealStream or FreqNoiseModel).
     """
 
     def process(self, hv):
@@ -1313,40 +1319,82 @@ class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
 
         Returns
         -------
-        ss : containers.SiderealStream
-            A sidereal stream with visibilities set to zero and
-            with weights proportional to the baseline redundancy
-            and normalized to reproduce the input weights after
-            beamforming in the north-south direction.
+        out : determined by sub-class
         """
-        # Extract parameters needed to calculate the window
-        # function in the y direction
-        weight = hv.attrs["beamform_ns_weight"]
-        if weight == "inverse_variance":
+        # Extract the parameters describing the window function
+        # from the attributs of the input container
+        self._parse_attrs(hv.attrs)
+
+        # Redistribute the input over the desired axis using a sub-class method.
+        # Returns the frequencies being handled by this rank.
+        freq = self._redistribute_input(hv)
+
+        # Calculate parameters describing the baseline layout
+        layout = self._compute_layout(hv)
+
+        # Calculate the window as a function of north-south baseline
+        window = self._compute_window(freq, layout)
+
+        # Create output container using sub-class method
+        return self._fill_output(hv, window, layout)
+
+    def _parse_attrs(self, attrs):
+        """Extract beamforming parameters from input container attributes."""
+        self.weight = attrs["beamform_ns_weight"]
+        if self.weight == "inverse_variance":
             raise ValueError("Weight scheme inverse_variance not supported.")
+        self.include_auto = attrs["beamform_ns_include_auto"]
+        self.scaled = attrs["beamform_ns_scaled"]
+        self.freqmin = attrs["beamform_ns_freqmin"]
+        self.nsmax = attrs["beamform_ns_nsmax"]
+        self.wvmin = scipy.constants.c * 1e-6 / self.freqmin
 
-        include_auto = hv.attrs["beamform_ns_include_auto"]
-        scaled = hv.attrs["beamform_ns_scaled"]
-        freqmin = hv.attrs["beamform_ns_freqmin"]
-        nsmax = hv.attrs["beamform_ns_nsmax"]
+    def _compute_layout(self, hv):
+        """Determine layout and redundancy of the baselines.
 
-        wvmin = scipy.constants.c * 1e-6 / freqmin
+        Parameters
+        ----------
+        hv : containers.HybridVisStream
+            Hybrid beamformed visibilities used to infer baseline layout
+            and redundancy.
 
-        # Calculation the set of polarisations in the data, and which polarisation
-        # index every entry corresponds to
+        Returns
+        -------
+        layout : dict
+            A dictionary of layout parameters including:
+            - "xind", "yind": east-west and north-south grid indices
+            - "pind": polarisation indices
+            - "ewpos", "nspos": axis coordinate arrays
+            - "nbaseline_grid": grid of redundancy values
+            - "nbaseline": redundancy per baseline
+            - "flag": boolean baseline inclusion flag
+            - "pconjmap": polarisation conjugate remapping
+            - "npol", "nx", "ny": axis sizes
+        """
+        # Determine the set of polarisation pairs in the telescope,
+        # and which polarisation pair every baseline corresponds to.
         polpair = self.telescope.polarisation[self.telescope.uniquepairs].view("U2")
         polpair, pind = np.unique(polpair, return_inverse=True)
 
-        # Determine the layout of the visibilities on the grid.
-        xind, yind, min_xsep, min_ysep = find_grid_indices(self.telescope.baselines)
+        # Downselect to only the polarisations present in hv
+        pol = hv.index_map["pol"]
+        npol = pol.size
 
-        baseline_flag = np.abs(yind * min_ysep) <= (nsmax + 0.5 * min_ysep)
+        pol_lookup = {key: ind for ind, key in enumerate(pol)}
+        pol_remap = np.array([pol_lookup.get(pstr, -1) for pstr in polpair[pind]])
+        pol_flag = pol_remap >= 0
+
+        # Determine the layout of the visibilities on the grid
+        xind, yind, min_xsep, min_ysep = tools.find_grid_indices(
+            self.telescope.baselines
+        )
+        baseline_flag = np.abs(yind * min_ysep) <= (self.nsmax + 0.5 * min_ysep)
 
         # Determine north-south grid
         ny = 2 * np.abs(yind).max() + 1
         nspos = np.fft.fftfreq(ny, d=(1.0 / (ny * min_ysep)))
 
-        # Check that the input container has the same east-west grid
+        # Confirm that that input container has the full east-west grid
         vis_pos_x = np.arange(np.max(np.abs(xind)) + 1) * min_xsep
 
         ewpos = hv.index_map["ew"]
@@ -1355,24 +1403,142 @@ class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
         if not np.array_equal(vis_pos_x, ewpos):
             raise RuntimeError("Downselected ew axis not currently supported.")
 
-        # Select the polarisations present in hvis
-        pol = hv.index_map["pol"]
-        npol = pol.size
-
-        pol_lookup = {key: ind for ind, key in enumerate(hv.pol)}
-
-        pol_remap = np.array([pol_lookup.get(pstr, -1) for pstr in polpair[pind]])
-        pol_flag = pol_remap >= 0
-
         # Downselect the baselines to process
         flag = pol_flag & baseline_flag
-
-        xind = xind[flag]
-        yind = yind[flag]
-        pind = pol_remap[flag]
+        xind, yind, pind = xind[flag], yind[flag], pol_remap[flag]
 
         pconjmap = np.unique([pj + pi for pi, pj in pol], return_inverse=True)[1]
 
+        # Calculate the redundancy of the baseline
+        input_flags = np.all(self.telescope.feedmask, axis=-1, keepdims=True)
+        nbaseline = tools.calculate_redundancy(
+            input_flags, self.bt_prod, self.bt_rev["stack"], self.bt_stack.size
+        )[:, 0]
+
+        nbaseline_valid = nbaseline[flag]
+
+        # Place the redundancy onto a regular grid
+        nbaseline_grid = np.zeros((npol, nx, ny), dtype=float)
+        nbaseline_grid[pind, xind, yind] = nbaseline_valid
+
+        intra = np.flatnonzero(xind == 0)
+        nbaseline_grid[pconjmap[pind[intra]], 0, -yind[intra]] = nbaseline_valid[intra]
+
+        # Return all parameters describing the baseline layout
+        return {
+            "xind": xind,
+            "yind": yind,
+            "pind": pind,
+            "ewpos": ewpos,
+            "nspos": nspos,
+            "nbaseline_grid": nbaseline_grid,
+            "nbaseline": nbaseline,
+            "flag": flag,
+            "pconjmap": pconjmap,
+            "npol": npol,
+            "nx": nx,
+            "ny": ny,
+        }
+
+    def _compute_window(self, freq, layout):
+        """Compute the window as a function of north-south baseline.
+
+        Parameters
+        ----------
+        freq : ndarray
+            Compute the window at these frequencies.
+        layout : dict
+            Dictionary of parameters describing baseline layout as
+            returned by `_compute_layout`.
+
+        Returns
+        -------
+        window : np.ndarray[npol, nfreq, nx, ny]
+            Normalized window function.
+        """
+        nfreq = freq.size
+        window = np.empty(
+            (layout["npol"], nfreq, layout["nx"], layout["ny"]), dtype=float
+        )
+
+        if self.weight == "natural":
+            # Window equal to redundancy for natural weighting
+            window[:] = layout["nbaseline_grid"][:, np.newaxis]
+
+        else:
+            # Calculate window function for each frequency
+            wavelength = scipy.constants.c * 1e-6 / freq
+            for ff, wv in enumerate(wavelength):
+                vpos = layout["nspos"] / wv
+                vmax = self.nsmax / self.wvmin if self.scaled else self.nsmax / wv
+                x = 0.5 * (vpos / vmax + 1)
+
+                window[:, ff, :, :] = tools.window_generalised(x, window=self.weight)
+
+        # Exclude intra-cylinder baselines
+        if self.include_auto:
+            window[:, :, 0, 0] = 0.0
+
+        # Normalize by sum of weights
+        norm = np.sum(window, axis=-1, keepdims=True)
+        return window * tools.invert_no_zero(norm)
+
+    def _redistribute_input(self, hv):
+        raise NotImplementedError(
+            "_redistribute_input must be implemented in subclass."
+        )
+
+    def _fill_output(self, hv, window, layout):
+        raise NotImplementedError("_fill_output must be implemented in subclass.")
+
+
+class ReconstructVisWeight(ReconstructVisNoiseBase):
+    """Generate visibility weights that reproduce hybrid beamformed weights.
+
+    This task creates a `SiderealStream` container with zeroed visibilities
+    and weights constructed such that, when north-south beamforming is applied
+    to the output, the resulting weights match those in the input `HybridVisStream`.
+    This is primarily useful for simulating noise with the proper correlations
+    as a function of el.
+    """
+
+    def _redistribute_input(self, hv):
+        """Redistribute input container over frequency.
+
+        Parameters
+        ----------
+        hv : containers.HybridVisStream
+            Hybrid beamformed visibility container to redistribute.
+
+        Returns
+        -------
+        freq : ndarray
+            The local frequency slice for the current rank.
+        """
+        hv.redistribute("freq")
+        return hv.freq[hv.weight[:].local_bounds]
+
+    def _fill_output(self, hv, window, layout):
+        """Construct sidereal stream whose weights match beamformed visibility weights.
+
+        Fills a sidereal stream container with weights such that after applying
+        hybrid beamforming in the north-south direction, the resulting weights
+        reproduce those in the input HybridVisStream.  Visibilities are set to zero.
+
+        Parameters
+        ----------
+        hv : containers.HybridVisStream
+            Input visibilities with beamforming weights to match.
+        window : ndarray
+            Normalized beamforming window function.
+        layout : dict
+            Dictionary of parameters describing baseline layout and redundancy.
+
+        Returns
+        -------
+        ss : containers.SiderealStream
+            Output container with weights scaled to match beamformed input.
+        """
         # Create output container
         ss = containers.SiderealStream(
             axes_from=hv,
@@ -1385,96 +1551,143 @@ class ReconstructVisWeight(transform.TelescopeStreamMixIn, task.SingleTask):
             comm=hv.comm,
         )
 
-        hv.redistribute("freq")
         ss.redistribute("freq")
-
-        # Assume that the noise variance scales with
-        # the redundancy of the baseline.
-        input_flags = np.all(self.telescope.feedmask, axis=-1, keepdims=True)
-        nbaseline = tools.calculate_redundancy(
-            input_flags,
-            ss.index_map["prod"],
-            ss.reverse_map["stack"]["stack"][:],
-            ss.vis.shape[1],
-        )[:, 0]
-
-        nbaseline_valid = nbaseline[flag]
-
-        # Place the redundancy onto a regular grid
-        nbaseline_grid = np.zeros((npol, nx, ny), dtype=float)
-        nbaseline_grid[pind, xind, yind] = nbaseline_valid
-
-        intra = np.flatnonzero(xind == 0)
-        nbaseline_grid[pconjmap[pind[intra]], 0, -yind[intra]] = nbaseline_valid[intra]
-
-        # Determine the wavelengths
-        wavelength = scipy.constants.c * 1e-6 / ss.freq[ss.weight[:].local_bounds]
-
-        # Initialize datasets in output container
         ss.vis[:] = 0.0
 
-        wss = ss.weight[:].local_array
+        # Construct the noise factor by summing over north-south baselines
+        noise_factor = np.sum(
+            window**2 * tools.invert_no_zero(layout["nbaseline_grid"][:, np.newaxis]),
+            axis=-1,
+        )
+
+        # Grab the weight from the hybrid beamformed visibilities
+        # and scale by the noise factor
+        w0 = hv.weight[:].local_array * noise_factor[..., np.newaxis]
 
         # Assume that the weight in the sidereal stream
-        # scales with redundancy
-        wss[:] = np.where(flag, nbaseline, 0.0)[np.newaxis, :, np.newaxis]
+        # is given by the base-weight w0 times the redundancy
+        wss = ss.weight[:].local_array
+        wss[:] = np.where(layout["flag"], layout["nbaseline"], 0.0)[
+            np.newaxis, :, np.newaxis
+        ]
 
-        # Dereference datasets in input container
-        whv = hv.weight[:].local_array
+        for ff in range(w0.shape[1]):
+            wss[ff][layout["flag"]] *= w0[layout["pind"], ff, layout["xind"], :]
 
-        # If natural weighting was used, then we can perform most of the
-        # calculation now, since it won't change with frequency
-        if weight == "natural":
+        # Return sidereal stream with visibility set to zero and weight set to a
+        # value that when beamformed will yield the weight in the input container.
+        return ss
 
-            window = nbaseline_grid.copy()
 
-            # Remove auto-correlations
-            if not include_auto:
-                window[:, 0, 0] = 0.0
+class ReconstructVisFreqCov(ReconstructVisNoiseBase):
+    """Decompose frequency-frequency covariance for simulating correlated noise.
 
-            # Normalize by sum of weights
-            norm = np.sum(window, axis=-1, keepdims=True)
-            window *= tools.invert_no_zero(norm)
+    This task produces a `FreqNoiseModel` container with a Cholesky decomposition
+    of the frequency-frequency covariance matrix for each (pol, ew, ra) pixel.
+    These matrices are scaled to match the hybrid beamforming window and the
+    instrument's baseline redundancy.  The output enables generation of noise
+    realizations that preserve the correct frequency and el correlation structure.
+    """
 
-            # Conversion between weight in hybrid beamformed visibilities
-            # to weight in visibilities
-            noise_factor = np.sum(
-                window**2 * tools.invert_no_zero(nbaseline_grid), axis=-1
+    def _redistribute_input(self, hv):
+        """Redistribute input container over RA axis.
+
+        Parameters
+        ----------
+        hv : containers.HybridVisStream
+            Hybrid beamformed visibility container to redistribute.
+
+        Returns
+        -------
+        freq : ndarray
+            The full array of frequencies in the input container.
+        """
+        hv.redistribute("ra")
+        return hv.freq
+
+    def _fill_output(self, hv, window, layout):
+        """Generate Cholesky decomposition of frequency-frequency covariance.
+
+        Parameters
+        ----------
+        hv : containers.HybridVisStream
+            Hybrid beamformed visibilities.  Must contain a frequency-frequency
+            covariance matrix.
+        window : np.ndarray[npol, nfreq, nx, ny]
+            Window as a function of north-south baseline used during beamforming.
+        layout : dict
+            Dictionary of parameters describing the baseline layout and redundancy.
+
+        Returns
+        -------
+        out : containers.FreqNoiseModel
+            Container holding all datasets required to simulate noise with the
+            proper correlation as a function of frequency and el.  Includes the
+            redundancy of the instrument, the cholesky decomposition of the
+            frequency-frequency covariance matrix, and the weights.
+        """
+        # Create output container
+        out = containers.FreqNoiseModel(
+            axes_from=hv,
+            attrs_from=hv,
+            ns=layout["nspos"],
+            distributed=hv.distributed,
+            comm=hv.comm,
+        )
+
+        dataset_name = (
+            "complex_freq_cov" if "complex_freq_cov" in hv.datasets else "freq_cov"
+        )
+        out.add_dataset(dataset_name)
+
+        # Redistribute over RA
+        out.redistribute("ra")
+
+        # Save the redundancy
+        out.redundancy[:] = layout["nbaseline_grid"]
+
+        inv_nb = tools.invert_no_zero(layout["nbaseline_grid"][:, np.newaxis])
+
+        # Dereference covariance
+        cov_in = hv.freq_cov[:].local_array
+        flag = hv.weight[:].local_array > 0.0
+
+        cov_out = out.freq_cov[:].local_array
+        cov_out[:] = 0.0
+
+        weight_out = out.weight[:].local_array
+        weight_out[:] = 0.0
+
+        npol, nfreq, nfreqs, new, nra = cov_in.shape
+
+        # Construct the noise factor.  Shape is (pol, freq, freq_sum, ew).
+        noise_factor = np.empty(cov_in.shape[:-1], dtype=float)
+        for ff in range(nfreq):
+            noise_factor[:, ff] = np.sum(
+                window[:, ff, np.newaxis] * window * inv_nb, axis=-1
             )
 
-        # Loop over local frequencies
-        for ff, wv in enumerate(wavelength):
+        inv_noise_factor = tools.invert_no_zero(noise_factor)
 
-            # If natural weighting was not used, then caclulate the
-            # window function based on the frequency.
-            if weight != "natural":
+        # Loop over pol, ew baseline, and RA.
+        for pp in range(npol):
+            for ee in range(new):
+                for rr in range(nra):
+                    # Get frequencies with non-zero weight.
+                    valid = np.flatnonzero(flag[pp, :, ee, rr])
+                    valid_2d = np.ix_(valid, valid)
 
-                vpos = nspos / wv
-                vmax = nsmax / wvmin if scaled else nsmax / wv
+                    # Get the covariance of the beamformed data and normalize by the noise factor.
+                    C = cov_in[pp, :, :, ee, rr] * inv_noise_factor[pp, :, :, ee]
+                    C = C[valid_2d]
 
-                x = 0.5 * (vpos / vmax + 1)
-                window = np.ones((npol, nx, ny), dtype=float)
-                window *= tools.window_generalised(x, window=weight)
+                    # Save the weight dataset as the inverse of the diagonal of the covariance.
+                    weight_out[pp, :, ee, rr][valid] = tools.invert_no_zero(np.diag(C))
 
-                # Remove auto-correlations
-                if not include_auto:
-                    window[:, 0, 0] = 0.0
+                    # Perform the cholesky decomposition.  Batch over the RA axis.
+                    cov_out[pp, ee, rr][valid_2d] = np.linalg.cholesky(C)
 
-                # Normalize by sum of weights
-                norm = np.sum(window, axis=-1, keepdims=True)
-                window *= tools.invert_no_zero(norm)
-
-                # Conversion between weight in hybrid beamformed visibilities
-                # to weight in visibilities
-                noise_factor = np.sum(
-                    window**2 * tools.invert_no_zero(nbaseline_grid), axis=-1
-                )
-
-            w0 = noise_factor[:, :, np.newaxis] * whv[:, ff, :, :]
-
-            wss[ff][flag] *= w0[pind, xind, :]
-
-        return ss
+        return out
 
 
 def find_basis(baselines):

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -88,7 +88,8 @@ class MakeVisGrid(task.SingleTask):
 
         # Calculation the set of polarisations in the data, and which polarisation
         # index every entry corresponds to
-        polpair = self.telescope.polarisation[self.telescope.uniquepairs].view("U2")
+        polprod = self.telescope.polarisation[self.telescope.uniquepairs]
+        polpair = np.char.add(polprod[:, 0], polprod[:, 1])
         pol, pind = np.unique(polpair, return_inverse=True)
 
         if len(pol) != 4:
@@ -1373,7 +1374,8 @@ class ReconstructVisNoiseBase(transform.TelescopeStreamMixIn, task.SingleTask):
         """
         # Determine the set of polarisation pairs in the telescope,
         # and which polarisation pair every baseline corresponds to.
-        polpair = self.telescope.polarisation[self.telescope.uniquepairs].view("U2")
+        polprod = self.telescope.polarisation[self.telescope.uniquepairs]
+        polpair = np.char.add(polprod[:, 0], polprod[:, 1])
         polpair, pind = np.unique(polpair, return_inverse=True)
 
         # Downselect to only the polarisations present in hv
@@ -1385,9 +1387,7 @@ class ReconstructVisNoiseBase(transform.TelescopeStreamMixIn, task.SingleTask):
         pol_flag = pol_remap >= 0
 
         # Determine the layout of the visibilities on the grid
-        xind, yind, min_xsep, min_ysep = tools.find_grid_indices(
-            self.telescope.baselines
-        )
+        xind, yind, min_xsep, min_ysep = find_grid_indices(self.telescope.baselines)
         baseline_flag = np.abs(yind * min_ysep) <= (self.nsmax + 0.5 * min_ysep)
 
         # Determine north-south grid

--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -553,10 +553,13 @@ class SiderealRebinner(SiderealRegridder):
 
         # Initialize any missing datasets
         alt_dspec = {}
+        contains_covariance = False
         for name, dataset in data.datasets.items():
             if name not in sdata.datasets:
                 alt_dspec[name] = dataset.attrs["axis"]
                 sdata.add_dataset(name)
+                if "freq_cov" in name:
+                    contains_covariance = True
 
         sdata.add_dataset("effective_ra")
         sdata.add_dataset("nsample")
@@ -587,7 +590,16 @@ class SiderealRebinner(SiderealRegridder):
         ssn = sdata.nsample[:].local_array
         salt = {name: sdata.datasets[name][:].local_array for name in alt_dspec.keys()}
 
-        lookup = {name: nn for nn, name in enumerate(data.vis.attrs["axis"][:-2])}
+        vax = data.vis.attrs["axis"][:-2]
+        lookup = {name: nn for nn, name in enumerate(vax)}
+
+        # If the input data product contains a freq-freq covariance matrix,
+        # then we will need access to the weight dataset for all frequencies.
+        if contains_covariance:
+            if self.weight == "uniform":
+                weight_all = (data.weight[:] > 0.0).allgather()
+            else:
+                weight_all = data.weight[:].allgather()
 
         # Loop over all but the last two axes.
         # For an input TimeStream, this will be a loop over freq.
@@ -611,6 +623,14 @@ class SiderealRebinner(SiderealRegridder):
             # Count number of samples
             ssn[ind] = m @ Rt
 
+            # Compute factors needed for the covariance calculation
+            if contains_covariance:
+                iall = tuple(
+                    ii if ax != "freq" else slice(None) for ii, ax in zip(ind, vax)
+                )
+                wall = weight_all[iall]
+                nall = tools.invert_no_zero(wall @ Rt)
+
             # Weighted rebin of other datasets
             for name, axis in alt_dspec.items():
                 aind = tuple(
@@ -620,7 +640,12 @@ class SiderealRebinner(SiderealRegridder):
                     ]
                 )
 
-                salt[name][aind] = norm * ((alt_data[name][aind] * w) @ Rt)
+                if "freq_cov" in name:
+                    salt[name][aind] = (
+                        norm * nall * ((alt_data[name][aind] * w * wall) @ Rtsq)
+                    )
+                else:
+                    salt[name][aind] = norm * ((alt_data[name][aind] * w) @ Rt)
 
             # Weighted rebin of the effective RA
             effective_lsd = norm * ((timestamp_lsd * w) @ Rt)
@@ -780,7 +805,7 @@ class SiderealStacker(task.SingleTask):
                 f"type(stack) (={type(self.stack)})."
             )
 
-        sdata.redistribute("freq")
+        sdata.redistribute("ra")
 
         # Get the LSD (or CSD) label out of the input's attributes.
         # If there is no label, use a placeholder.
@@ -826,12 +851,16 @@ class SiderealStacker(task.SingleTask):
 
                     # Create a slice into the weight dataset that will allow it
                     # to be broadcasted against the additional dataset.
-                    self.weight_slice[name] = get_slice_to_broadcast(
-                        wax, dataset.attrs["axis"]
-                    )
+                    wslc1 = get_slice_to_broadcast(wax, dataset.attrs["axis"])
+
+                    if "freq_cov" in name:
+                        wslc2 = get_slice_to_broadcast(wax, sdata.swapped_freq_cov_axis)
+                        self.weight_slice[name] = (wslc1, wslc2)
+                    else:
+                        self.weight_slice[name] = wslc1
 
             # Now that we have all datasets, redistribute over frequency.
-            self.stack.redistribute("freq")
+            self.stack.redistribute("ra")
 
             # Initialize all datasets to zero.
             for data in self.stack.datasets.values():
@@ -898,8 +927,11 @@ class SiderealStacker(task.SingleTask):
         # Update any additional datasets.  Note this will include the effective_ra.
         for name in self.additional_datasets:
             wslc = self.weight_slice[name]
-            delta = coeff[wslc] * (sdata[name][:] - self.stack[name][:])
-            self.stack[name][:] += delta * inv_sum_coeff[wslc]
+            if "freq_cov" in name:
+                self.stack[name][:] += coeff[wslc[0]] * coeff[wslc[1]] * sdata[name][:]
+            else:
+                delta = coeff[wslc] * (sdata[name][:] - self.stack[name][:])
+                self.stack[name][:] += delta * inv_sum_coeff[wslc]
 
         # The calculations below are only required if the sample variance was requested
         if self.with_sample_variance:
@@ -932,17 +964,23 @@ class SiderealStacker(task.SingleTask):
             self.stack.weight[:] = tools.invert_no_zero(self.stack.weight[:]) * norm**2
 
         else:
-            # For inverse variance weighting without rebinning,
-            # additional normalization is not required.
-            norm = None
+            # For inverse variance weighting the stack.weight dataset is finalized,
+            # no additional normalization is required.
+            norm = self.stack.weight[:]
+
+        # Apply the inverse squared norm factor to any dataset that is a
+        # freq-freq covariance
+        for name in self.additional_datasets:
+            if "freq_cov" in name:
+                wslc = self.weight_slice[name]
+                self.stack[name][:] *= tools.invert_no_zero(
+                    norm[wslc[0]] * norm[wslc[1]]
+                )
 
         # We need to normalize the sample variance by the sum of coefficients.
         # Can be found in the stack.nsample dataset for uniform case
         # or the stack.weight dataset for inverse variance case.
         if self.with_sample_variance:
-
-            if norm is None:
-                norm = self.stack.weight[:]
 
             # Perform Bessel's correction.  In the case of
             # uniform  weighting, norm will be equal to nsample - 1.
@@ -954,9 +992,12 @@ class SiderealStacker(task.SingleTask):
                 self.stack.nsample[:] > 1, tools.invert_no_zero(norm), 0.0
             )[wslc]
 
+        # Now redistribute back over frequency
+        self.stack.redistribute("freq")
+
+        # For samples where there is no data, the effective ra should
+        # be the same as the grid ra
         if "effective_ra" in self.stack.datasets:
-            # For samples where there is no data, the effective ra should
-            # be the same as the grid ra
             weight = self.stack.weight[:].local_array
             era = self.stack.effective_ra[:].local_array
 

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1210,6 +1210,9 @@ class SelectPol(task.SingleTask):
                 elif np.issubdtype(out_dset.dtype, np.bool_):
                     pass
 
+                elif "freq_cov" in name:
+                    out_dset[oslc] /= nsum**2
+
                 else:
                     out_dset[oslc] /= nsum
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2405,6 +2405,69 @@ class RingMapTaper(FreqContainer, SiderealContainer):
         return self.datasets["taper"]
 
 
+class FreqNoiseModel(FilterFreqContainer, FreqContainer, SiderealContainer):
+    """Container storing Cholesky factors of frequency-frequency noise covariance.
+
+    This container is intended for generating noise realizations in visibility space
+    that include the desired correlations as a function of freq and el.  This is
+    typically used to populate a VisGridStream container with synthetic noise having
+    a specific spectral structure.
+    """
+
+    _axes = ("pol", "ew", "ns")
+
+    _dataset_spec: ClassVar = {
+        "redundancy": {
+            "axes": ["pol", "ew", "ns"],
+            "dtype": np.int32,
+            "initialise": True,
+            "distributed": False,
+            "chunks": (1, 1, 128),
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+        },
+        "weight": {
+            "axes": ["pol", "freq", "ew", "ra"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "chunks": (1, 64, 1, 2048),
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+        },
+        "freq_cov": {
+            "axes": ["pol", "ew", "ra", "freq", "freq_sum"],
+            "dtype": np.float64,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "ra",
+            "chunks": (1, 1, 2048, 64, 64),
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+        },
+        "complex_freq_cov": {
+            "axes": ["pol", "ew", "ra", "freq", "freq_sum"],
+            "dtype": np.complex128,
+            "initialise": False,
+            "distributed": True,
+            "distributed_axis": "ra",
+            "chunks": (1, 1, 2048, 64, 64),
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+        },
+    }
+
+    @property
+    def redundancy(self):
+        """Get the redundancy dataset."""
+        return self.datasets["redundancy"]
+
+    @property
+    def weight(self):
+        """Get the weight dataset."""
+        return self.datasets["weight"]
+
+
 class GainDataBase(DataWeightContainer):
     """A container interface for gain-like data.
 

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -2767,7 +2767,7 @@ class DelayTransformOperator(DelayContainer, FreqContainer, SiderealContainer):
 
     @property
     def filter(self):
-        """Get the mask dataset."""
+        """Get the filter dataset."""
         return self.datasets["filter"]
 
 

--- a/draco/synthesis/noise.py
+++ b/draco/synthesis/noise.py
@@ -123,13 +123,16 @@ class GaussianNoiseDataset(task.SingleTask, random.RandomTask):
         return out
 
 
-class MultipleGaussianNoiseDatasets(GaussianNoiseDataset):
-    """Generates multiple Gaussian distributed noise datasets.
+class MultipleNoiseRealizationsMixin:
+    """Generates multiple noise realizations with the same underlying statistics.
+
+    This is a non-functional class mixin that must be combined with a class whose
+    process method generates a single noise realization.
 
     Attributes
     ----------
     niter : int
-        Number of Gaussian noise datasets to generate.
+        Number of noise realizations to generate.
     """
 
     niter = config.Property(proptype=int, default=1)
@@ -163,6 +166,12 @@ class MultipleGaussianNoiseDatasets(GaussianNoiseDataset):
             raise pipeline.PipelineStopIteration
 
         return super().process(self.data[self._count % len(self.data)])
+
+
+class MultipleGaussianNoiseDatasets(
+    MultipleNoiseRealizationsMixin, GaussianNoiseDataset
+):
+    """Generates multiple Gaussian distributed noise datasets."""
 
 
 class GaussianNoise(task.SingleTask, random.RandomTask):
@@ -364,3 +373,94 @@ class SampleNoise(task.SingleTask, random.RandomTask):
                 )
 
         return data_exp
+
+
+class FreqCorrelatedNoise(task.SingleTask, random.RandomTask):
+    """Generate frequency-correlated noise using Cholesky factors.
+
+    This task uses precomputed Cholesky decompositions of the frequency-frequency
+    noise covariance (stored in a FreqNoiseModel container) to simulate
+    a noise realization into a VisGridStream container.
+    """
+
+    def process(self, noise_model):
+        """Simulate noise into a VisGridStream container.
+
+        Parameters
+        ----------
+        noise_model : containers.FreqNoiseModel
+            Input noise model containing Cholesky factors and baseline redundancy.
+
+        Returns
+        -------
+        out : containers.VisGridStream
+            Container filled with a frequency-correlated noise realization.
+        """
+        noise_model.redistribute("ra")
+
+        out = containers.VisGridStream(
+            axes_from=noise_model,
+            attrs_from=noise_model,
+            distributed=noise_model.distributed,
+            comm=noise_model.comm,
+        )
+        out.redistribute("ra")
+
+        # Compute the redundancy factor that determines how the noise depends
+        # on north-south baseline distance
+        redundancy = noise_model.redundancy[:]
+        inv_sqrt_redundancy = tools.invert_no_zero(np.sqrt(redundancy))
+
+        # Dereference datasets
+        L = noise_model.freq_cov[:].local_array
+        weight = noise_model.weight[:].local_array
+
+        ovis = out.vis[:].local_array
+        oweight = out.weight[:].local_array
+
+        npol, nfreq, new, nns, nra = ovis.shape
+
+        # Loop over pol and ew to reduce memory usage
+        for pp in range(npol):
+
+            for ee in range(new):
+
+                # Generate a set of complex random numbers with unit standard deviation
+                z = np.empty((nra, nfreq, nns), dtype=ovis.dtype)
+
+                random.complex_normal(
+                    scale=1.0,
+                    out=z,
+                    rng=self.rng,
+                )
+
+                # Multiply by the Cholesky decomposition of the freq-freq covariance matrix
+                # to introduce the desired correlation as a function of frequency, then divide
+                # by the square root of the redundancy of the baseline.
+                sz = np.matmul(L[pp, ee], z) * inv_sqrt_redundancy[pp, ee]
+
+                ovis[pp, :, ee] = sz.transpose(1, 2, 0)
+
+                oweight[pp, :, ee] = (
+                    weight[pp, :, ee, np.newaxis, :] * redundancy[pp, ee, :, np.newaxis]
+                )
+
+        # Ensure that the visibility matrix is Hermitian
+        nyp = nns // 2 + 1
+        slc_pos = slice(1, nyp)
+        slc_neg = slice(-1, -nyp, -1)
+
+        pconjmap = np.unique(
+            [pj + pi for pi, pj in out.index_map["pol"]], return_inverse=True
+        )[1]
+
+        for pi, po in enumerate(pconjmap):
+            ovis[po, :, 0, slc_neg, :] = ovis[pi, :, 0, slc_pos, :].conj()
+            if pi == po:
+                ovis[po, :, 0, 0, :] = ovis[pi, :, 0, 0, :].real * 2**0.5
+
+        return out
+
+
+class MultipleFreqCorrelatedNoise(MultipleNoiseRealizationsMixin, FreqCorrelatedNoise):
+    """Generates multiple realizations of frequency-correlated noise."""

--- a/draco/synthesis/noise.py
+++ b/draco/synthesis/noise.py
@@ -381,7 +381,14 @@ class FreqCorrelatedNoise(task.SingleTask, random.RandomTask):
     This task uses precomputed Cholesky decompositions of the frequency-frequency
     noise covariance (stored in a FreqNoiseModel container) to simulate
     a noise realization into a VisGridStream container.
+
+    Attributes
+    ----------
+    save_redundancy : bool
+        If True, save the redundancy of each visibility.  Default is False.
     """
+
+    save_redundancy = config.Property(proptype=bool, default=False)
 
     def process(self, noise_model):
         """Simulate noise into a VisGridStream container.
@@ -405,6 +412,10 @@ class FreqCorrelatedNoise(task.SingleTask, random.RandomTask):
             comm=noise_model.comm,
         )
         out.redistribute("ra")
+
+        if self.save_redundancy:
+            out.add_dataset("redundancy")
+            out.redundancy[:] = noise_model.redundancy[:][..., np.newaxis]
 
         # Compute the redundancy factor that determines how the noise depends
         # on north-south baseline distance


### PR DESCRIPTION
Applying the Dayenu filter introduces off-diagonal terms in the
frequency-frequency noise covariance matrix.  Update the following
tasks to calculate this covariance matrix:

    - DayenuDelayFilterHybridVis
    - DayenuDelayFilterHybridVis
    - DelayFilterHyFoReSBandpassHybridVisClean

Also update the following tasks to propagate this covariance matrix
through the pipeline:

    - SiderealRebinner
    - SiderealStacker
    - RADependentWeights
    - SelectPol

The covariance matrix is saved as a new dataset named either
freq_cov or complex_freq_cov in the HybridVisStream or RingMap,
similar to how the filter itself is saved.

Creates two new tasks:

    - ConstructWienerDelayTransform
    - ApplyWienerDelayTransform

that implement a Wiener-filtered delay transform that:
    - handles frequency masks with non-uniform coverage
    - accounts for filtering applied to the data
    - uses the tracked frequency-frequency noise covariance
    - estimates the signal covariance from simulations

This approach avoids the need to estimate the delay power spectrum
via Gibbs+Wiener or NRML methods, instead assuming 21 cm signal + noise
and relying on the propagated frequency-domain covariances.

Creates a ReconstructVisFreqCov task that generates a FreqNoiseModel container
with the ingredients to synthesize noise with a specified frequency-frequency
covariance. It reuses logic from ReconstructVisWeight, which is now refactored
into a shared base class, ReconstructVisNoiseBase.

Creates FreqCorrelatedNoise and MultipleFreqCorrelatedNoise tasks that use
the FreqNoiseModel container to synthesize noise with the correct correlations
in frequency and el.

Finally, creates a TaperDelayTransform task that can apply a taper to the
delay transform.  The existing task will not work for this purpose due to
the way the axes are collaped in the DelayTransform container.
