### PR TITLE
Implement a GP regridder

### DIFF
--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -19,7 +19,7 @@ from cora.util import units
 from ..core import containers, io, task
 from ..util import gaussian_process, regrid, tools
 from .interpolate import _inv_move_front, _move_front
-from .transform import Regridder
+from .transform import LanczosRegridder
 
 
 class SiderealGrouper(task.SingleTask):
@@ -155,7 +155,7 @@ class SiderealGrouper(task.SingleTask):
         return ts
 
 
-class SiderealRegridder(Regridder):
+class SiderealRegridder(LanczosRegridder):
     """Take a sidereal days worth of data, and put onto a regular grid.
 
     Uses a maximum-likelihood inverse of a Lanczos interpolation to do the
@@ -170,19 +170,6 @@ class SiderealRegridder(Regridder):
     """
 
     down_mix = config.Property(proptype=bool, default=False)
-
-    def setup(self, manager):
-        """Set the local observers position.
-
-        Parameters
-        ----------
-        manager : :class:`~caput.time.Observer`
-            An Observer object holding the geographic location of the telescope.
-            Note that :class:`~drift.core.TransitTelescope` instances are also
-            Observers.
-        """
-        # Need an Observer object holding the geographic location of the telescope.
-        self.observer = io.get_telescope(manager)
 
     def process(self, data):
         """Regrid the sidereal day.

--- a/draco/analysis/sidereal.py
+++ b/draco/analysis/sidereal.py
@@ -502,12 +502,12 @@ class SiderealRebinner(SiderealRegridder):
 
         Parameters
         ----------
-        data : containers.TimeStream
+        data : containers.TimeStream | containers.SiderealStream | containers.HybridVisStream
             Timestream data for the day (must have a `LSD` attribute).
 
         Returns
         -------
-        sdata : containers.SiderealStream
+        sdata : containers.SiderealStream | containers.HybridVisStream
             The regularly gridded sidereal timestream.
         """
         import scipy.sparse as ss
@@ -519,6 +519,7 @@ class SiderealRebinner(SiderealRegridder):
         # Determine output container based on input container
         container_map = {
             containers.TimeStream: containers.SiderealStream,
+            containers.SiderealStream: containers.SiderealStream,
             containers.HybridVisStream: containers.HybridVisStream,
         }
 

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -849,8 +849,8 @@ def _unpack_marray(mmodes, n=None):
     return marray
 
 
-class Regridder(task.SingleTask):
-    """Interpolate time-ordered data onto a regular grid.
+class LanczosRegridder(task.SingleTask):
+    """Interpolate the time-like axis of a dataset onto a regular grid.
 
     Uses a maximum-likelihood inverse of a Lanczos interpolation to do the
     regridding. This gives a reasonably local regridding, that is pretty well
@@ -891,7 +891,7 @@ class Regridder(task.SingleTask):
             Note that :class:`~drift.core.TransitTelescope` instances are also
             Observers.
         """
-        self.observer = observer
+        self.observer = io.get_telescope(observer)
 
     def process(self, data):
         """Regrid visibility data in the time direction.
@@ -982,6 +982,10 @@ class Regridder(task.SingleTask):
             ni *= w_mask[..., np.newaxis]
 
         return interp_grid, sts, ni
+
+
+# Alias for compatibility
+Regridder = LanczosRegridder
 
 
 class ShiftRA(task.SingleTask):

--- a/draco/util/_fast_tools.pyx
+++ b/draco/util/_fast_tools.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 """A few miscellaneous Cython routines to speed up critical operations."""
 
 from cython.parallel import prange, parallel

--- a/draco/util/dpss.py
+++ b/draco/util/dpss.py
@@ -482,7 +482,7 @@ def atleast_Nd(x: np.ndarray, N: int, lax: int = -1):
     add = (..., *newdims, *slobj)
     inv = (..., *(0 for _ in newdims), *slobj)
 
-    return x[add], inv
+    return x[add], np.s_[inv]
 
 
 def _check_shape(x: np.ndarray, A: np.ndarray, copy: bool = False):

--- a/draco/util/gaussian_process.py
+++ b/draco/util/gaussian_process.py
@@ -1,0 +1,353 @@
+"""Routines for Gaussian Process Regression."""
+
+import numpy as np
+import scipy.linalg as la
+from caput.tools import invert_no_zero
+
+from . import _fast_tools, kernels
+from .dpss import _dtype_to_real
+
+
+def resample(
+    data: np.ndarray[np.floating | np.complexfloating],
+    weight: np.ndarray[np.floating],
+    xi: np.ndarray[np.number],
+    xo: np.ndarray[np.number],
+    cutoff_dist: float = 1.0,
+    cutoff_partition: int = 0,
+    kernel_spec: list | tuple | dict = {},
+) -> tuple[np.ndarray[np.floating | np.complexfloating], np.ndarray[np.floating]]:
+    """Resample a dataset using a GP kernel.
+
+    Parameters
+    ----------
+    data
+        Data array. Iterate over the first axis and interpolate the second.
+        Samples are assumed to be constant over the third axis.
+    weight
+        Data weights, broadcastable to the shape of `data`.
+    xi
+        Samples where data points have been measured
+    xo
+        Samples we want to interpolate onto.
+    cutoff_dist
+        Maximum distance from nearest unflagged input sample to keep
+        output samples.
+    cutoff_partition
+        Propagate flag cutoff to `n` closest sample. Goes into `np.partition`.
+        Value of 0 is equivalent to the closest sample. Default is 0.
+    kernel_spec
+        Kernel type and structure parameters. Can be provided as a single
+        dict for a single kernel, or a list | tuple of dicts to combine
+        multiple kernels.
+
+    Returns
+    -------
+    xout
+        Resampled data array.
+    wout
+        Resampled weight array.
+    """
+    # Handle any number of kernel specs as a list
+    if not isinstance(kernel_spec, list | tuple):
+        kernel_spec = [kernel_spec]
+
+    # Get the kernels based on the kernel parameters
+    Ki, Ks = _combine_gp_kernels_from_specs((xo, xi), kernel_spec)
+
+    # Select the samples to interpolate to. The kernel width is required,
+    # so extract the widest kernel from the spec(s).
+    kwidth = 0.0
+    for spec in kernel_spec:
+        if (kw := spec.get("width", 0.0)) > kwidth:
+            kwidth = kw
+
+    inp_mask = ~np.all(weight == 0, axis=-1)
+    xm = _select_interp_samples(xi, xo, inp_mask, kwidth, cutoff_dist, cutoff_partition)
+
+    return interpolate_unweighted(data, weight, Ki, Ks, interp_samples=xm)
+
+
+def interpolate_unweighted(
+    data: np.ndarray[np.floating | np.complexfloating],
+    weight: np.ndarray[np.floating],
+    K: np.ndarray[np.floating],
+    Kstar: np.ndarray[np.floating],
+    interp_samples: np.ndarray[bool] | None = None,
+) -> tuple[np.ndarray[np.floating | np.complexfloating], np.ndarray[np.floating]]:
+    """Interpolate data using a GP kernel, assuming the signal is noise-free.
+
+    Iterate the first axis and interpolate the second.
+
+    Parameters
+    ----------
+    data
+        Signal array. Iterate over the first axis and interpolate over the second.
+        The third axis is a flattened combination of any other data axis over
+        which the data masking is constant.
+    weight
+        Inverse-variance weight array, with the same first two axes as `data`.
+    K
+        Source samples kernel.
+    Kstar
+        Projection kernel.
+    interp_samples
+        Boolean array corresponding to a subset of the target samples
+        onto which the data is projected. This is equivalent
+        to masking certain samples after interpolating, but provides a
+        performance improvement because there are fewer unnecessary
+        operations. If None, interpolate onto all samples.
+        Default is None.
+
+    Returns
+    -------
+    xout
+        Interpolated signal.
+    woud
+        Interpolated inverse-variance weights.
+
+    Raises
+    ------
+    scipy.linalg.LinAlgError
+        Raised if kernel `K` is not positive-definite. GP kernels are only
+        required to be positive semi-definite, but this function requires a
+        positive-definite kernel. This can usually be resolved by adding a
+        small `epsilon` value to the diagonal of `K`, which is specified by
+        the `epsilon` parameter of the `kernel_spec` argument in
+        `_build_gp_kernels_from_spec`.
+    """
+    # Choose a solve method. The banded solver has faster parallel
+    # performance, and is significantly faster when the kernel
+    # is relatively narrow. I've just hard-coded this flag for now.
+    _banded = True
+
+    def solve(ab, b):
+        if _banded:
+            return la.solveh_banded(ab, b, lower=True, check_finite=False)
+
+        return la.cho_solve(ab, b, check_finite=False)
+
+    def decomp(ab):
+        if _banded:
+            return kernels.convert_band_diagonal(ab, which="lower")
+
+        return la.cho_factor(ab, lower=True, check_finite=False)
+
+    # Make the output masking array
+    if interp_samples is None:
+        interp_samples = [slice(None)] * data.shape[0]
+
+    # If the signal is complex, interpolate the real and imaginary
+    # components independently, assuming the same error
+    data_dtype = data.dtype
+    interp_dtype = _dtype_to_real(data_dtype)
+
+    # Make the output arrays
+    nsamp = Kstar.shape[0]
+    xout = np.zeros((data.shape[0], nsamp, data.shape[-1]), dtype=data.dtype)
+    wout = np.zeros((weight.shape[0], nsamp, weight.shape[-1]), dtype=weight.dtype)
+
+    # Iterate the first axis and interpolate the second
+    for ii in range(data.shape[0]):
+        # Get the target sample mask and skip if all
+        # samples are ignored
+        mt = interp_samples[ii]
+
+        if not isinstance(mt, slice) and not np.any(mt):
+            continue
+
+        # Get source and target sample masks
+        wi = weight[ii]
+        mi = np.any(wi > 0, axis=-1)
+
+        # Decompose the kernel into a form which is faster to invert
+        kd = decomp(K[mi][:, mi])
+        # Solve for A = K_{s} K_{d}^{-1}, taking advantage
+        # of symmetry in K_{d}
+        A = solve(kd, Kstar[mt][:, mi].T).T.astype(np.float64, copy=False)
+        # Get kernel main band bounds
+        start, end = kernels._get_band_inds(A, tol=1.0e-8)
+
+        # Iterate the last axis, tranpose for faster iteration
+        # The fast cython utils only support 1D arrays at the moment
+        # Invert noise weights to get variance
+        vi = invert_no_zero(wi[mi].T)
+        xi = np.ascontiguousarray(data[ii][mi].T[..., np.newaxis])
+
+        # Allocate a temporary array to handle real or complex data
+        # The banded matmul only supports 1D double-type arrays
+        tmp = np.zeros(xout[0, mt].view(interp_dtype).shape, dtype=interp_dtype)
+
+        # Propagate noise covariance by solving N_{f} = A N_{i} A^{H}
+        for jj in range(vi.shape[0]):
+            vij = vi[jj].astype(np.float64)
+
+            if not np.any(vij > 0):
+                continue
+
+            # We could get the true inverse covariance diagonal:
+            # wout[ii, mt, jj] = np.diag(la.solveh_banded(ncov, eye, lower=False))
+            # with `eye` defined as a N x N identity. This is an order of
+            # magnitude slower than just inverting the diagonal. Maybe there's
+            # a faster way to get the inverse.
+            ncov = _fast_tools._linear_covariance_banded(A, vij, start, end, bw=0)
+            # This gets inverted later on, in a single operation
+            # outside of the loop
+            wout[ii, mt, jj] = ncov[-1]
+
+            # Multiply the data. Using this banded matmul is
+            # considerably faster than using numpy matmul.
+            # It's worth checking that this is still true every
+            # now and then. The equivalent operation would just be
+            # xout[ii, mt] = (A @ xi).view(data_dtype)
+            # outside of this second loop
+            xij = xi[jj].view(interp_dtype).T
+            # Multiply the real and imaginary components individually,
+            # if the data is complex
+            for kk in range(xij.shape[0]):
+                # There's a hidden type conversion here, from `float64`
+                # to `interp_dtype`
+                tmp[:, kk] = _fast_tools._matmul_banded(
+                    A, xij[kk].astype(np.float64), start, end
+                )
+            # Write to the output data array with the original data
+            # dtype (depending on whether it's real or complex)
+            xout[ii, mt, jj] = tmp.view(data_dtype)[:, 0]
+
+    # Invert the variance to get weights. Faster to do one
+    # operation here instead of inverting in the for loop
+    invert_no_zero(wout, out=wout)
+
+    # Weights shouldn't be negative - this is probably
+    # numerical error in a small number of samples
+    xout[wout < 0] = 0.0
+    wout[wout < 0] = 0.0
+
+    return xout, wout
+
+
+def _select_interp_samples(
+    xi: np.ndarray[np.number],
+    xo: np.ndarray[np.number],
+    mask: np.ndarray[bool],
+    kwidth: int,
+    cutoff: float,
+    partition: int = 0,
+) -> np.ndarray[bool]:
+    """Mask output samples which are more than some distance from input samples.
+
+    Parameters
+    ----------
+    xi
+        Samples where data points have been measured
+    xo
+        Samples we want to interpolate onto
+    mask
+        Mask corresponding to measured samples. `True` values are assumed
+        to be unflagged.
+    kwidth
+        Width of the interpolating kernel. Select only samples
+    cutoff
+        Select only output samples closer (in number of _input_ samples)
+        than this value to the `n`th nearest unflagged input sample.
+    partition
+        `n`th closest sample to consider when applying cutoff. This is fed into
+        `np.partition`. A value of `0` is relative to the nearest sample. Default
+        is 0.
+
+    Returns
+    -------
+    out
+        Mask with flagged samples set to `False`
+    """
+    dist = np.subtract.outer(xo, xi)
+    # Divide by the sample width to get the distance in number of input samples
+    dist /= np.median(np.abs(np.diff(xi)))
+
+    out = np.empty((mask.shape[0], xo.shape[0]), dtype=bool)
+
+    kw_cutoff = kwidth - 1
+
+    # Iterate over the first axis of `mask`
+    for ii in range(mask.shape[0]):
+        mi = mask[ii]
+
+        if not np.any(mi):
+            out[ii] = False
+            continue
+
+        dmi = dist[:, mi]
+
+        pdist = np.min(dmi, axis=-1, where=dmi > 0, initial=kw_cutoff)
+        ndist = np.max(dmi, axis=-1, where=dmi < 0, initial=-kw_cutoff)
+
+        out[ii] = np.maximum(pdist, abs(ndist)) < kw_cutoff
+        out[ii] &= np.partition(abs(dmi), partition, axis=-1)[:, partition] < cutoff
+
+    return out
+
+
+def _combine_gp_kernels_from_specs(
+    samples: tuple, kernel_params: list[dict] | tuple[dict] | dict
+) -> tuple[np.ndarray[np.floating], np.ndarray[np.floating]] | tuple[None, None]:
+    """Helper to combine multiple kernels from different specs."""
+    if not isinstance(kernel_params, list | tuple):
+        kernel_params = [kernel_params]
+
+    Ki = None
+    Ks = None
+    epsilon = None
+
+    for kspec in kernel_params:
+        # Remove the epsilon argument and accumulate on
+        # the combined kernel
+        var = kspec.pop("epsilon", 0.0)
+        # Build each individual kernel
+        ki, ks = _build_gp_kernels_from_spec(samples, kspec)
+
+        if Ki is None:
+            Ki = ki
+            Ks = ks
+            epsilon = np.zeros(Ki.shape[0], dtype=Ki.dtype)
+        else:
+            Ki *= ki
+            Ks *= ks
+
+        # Accumulate epsilon
+        epsilon[:] += var
+
+    np.einsum("ii->i", Ki)[:] += epsilon
+
+    return Ki, Ks
+
+
+def _build_gp_kernels_from_spec(
+    samples: tuple, kernel_spec: dict
+) -> tuple[np.ndarray[np.floating], np.ndarray[np.floating]]:
+    """Build a single kernel from a spec dictionary."""
+    # Do not modify the input spec dict
+    kernel_spec = kernel_spec.copy()
+    # Format the input samples
+    xi = samples[0]
+
+    if isinstance(xi, np.ndarray):
+        dx = np.median(np.abs(np.diff(xi)))
+    elif isinstance(xi, int):
+        dx = xi
+    else:
+        raise TypeError(
+            "Invalid type for `samples`. "
+            f"Expected `int` or `np.ndarray, got {type(xi)}."
+        )
+
+    # Scale the width by sample spacing
+    width = kernel_spec.pop("width", 1.0) * dx
+    name = kernel_spec.pop("name", "gaussian")
+    epsilon = kernel_spec.pop("epsilon", 0.0)
+
+    Ki = kernels.get_kernel(name=name, N=samples[1], width=width, **kernel_spec)
+    np.einsum("ii->i", Ki)[:] += epsilon
+
+    Ks = kernels.get_kernel(name=name, N=samples, width=width, **kernel_spec)
+
+    return Ki.astype(np.float64, copy=False), Ks.astype(np.float64, copy=False)

--- a/draco/util/kernels.py
+++ b/draco/util/kernels.py
@@ -1,9 +1,21 @@
 """Routines for creating kernel/covariance matrices."""
 
-from warnings import warn
-
 import numpy as np
+from scipy import linalg as la
 from scipy.spatial.distance import cdist
+
+__all__ = [
+    "convert_band_diagonal",
+    "euclidean_difference_kernel",
+    "gaussian_kernel",
+    "get_kernel",
+    "is_hermitian_positive_definite",
+    "matern_kernel",
+    "moving_average_inverse_kernel",
+    "periodic_kernel",
+    "rational_kernel",
+    "squared_difference_kernel",
+]
 
 
 def get_kernel(name: str, **kernel_params):
@@ -15,11 +27,23 @@ def get_kernel(name: str, **kernel_params):
         Name of the covariance function.
     kernel_params : dict
         Extra keyword arguments to pass to the kernel function.
+
+    Notes
+    -----
+    The `banded` argument is no longer honoured, and a full kernel
+    array is returned. The full kernel can be converted to
+    band-diagonal form with `convert_band_diagonal`.
     """
+    if "banded" in kernel_params:
+        import warnings
+
+        warnings.warn("The `banded` keyword is not longer used")
+
     kdict = {
         "gaussian": gaussian_kernel,
         "rational": rational_kernel,
         "matern": matern_kernel,
+        "periodic": periodic_kernel,
         "moving_average": moving_average_inverse_kernel,
     }
 
@@ -30,101 +54,17 @@ def get_kernel(name: str, **kernel_params):
             f"Invalid kernel type: '{name}'. " f"Valid kernels: {list(kdict.keys())}"
         )
 
-    kernel = kernelfunc(**kernel_params)
-
-    # Return a band diagonal kernel
-    if kernel_params.get("banded", False):
-        # Make sure this is a valid option
-        if (kernel.shape[0] != kernel.shape[1]) or not np.allclose(kernel, kernel.T):
-            raise ValueError(
-                "Cannot convert non-symmetric matrix to band diagonal. "
-                f"Got kernel with shape {kernel.shape}."
-            )
-
-        N = kernel_params["width"]
-        M = kernel.shape[0]
-        K = np.ones((N, M), dtype=kernel.dtype)
-
-        for i in range(N):
-            K[i, : M - i] = kernel.diagonal(i)
-
-        kernel = K
-
-    return kernel
+    return kernelfunc(**kernel_params)
 
 
-def _warn_unused_kwargs(kwargs):
-    """Warn if any unused arguments."""
-    if len(kwargs):
-        warn(f"Unused keyword arguments: {kwargs}.")
+# =======
+# Kernels
+# =======
 
 
-def squared_difference_kernel(N: int | tuple, width: int | tuple) -> np.ndarray:
-    """Create a distance matrix for a kernel using squared difference.
-
-    N : int | tuple
-        Number of samples over which to generate the kernel.
-        If this is a length-2 tuple, assume that this is a
-        correlation between two different sets of indices.
-    width : int | tuple
-        Width of the kernel along each axis. For a gaussian,
-        this is the standard deviation.
-
-    Returns
-    -------
-    diff : np.ndarray
-        Array of normalized distances.
-    """
-    # If only a single integer is provided, assume
-    # a square covariance matrix
-    if isinstance(N, int):
-        N = (N, N)
-
-    if isinstance(width, int):
-        width = (width, width)
-
-    if len(N) != 2 or len(width) != 2:
-        raise ValueError(f"Invalid parameters. Got N={N} and width={width}.")
-
-    i0 = np.arange(N[0]) / width[0]
-    i1 = np.arange(N[1]) / width[1]
-
-    return np.subtract.outer(i0, i1) ** 2
-
-
-def euclidean_difference_kernel(N: int | tuple, width: int | tuple) -> np.ndarray:
-    """Create a distance matrix for a kernel using euclidean difference.
-
-    N : int | tuple
-        Number of samples over which to generate the kernel.
-        If this is a length-2 tuple, assume that this is a
-        correlation between two different sets of indices.
-    width : int | tuple
-        Width of the kernel along each axis. For a gaussian,
-        this is the standard deviation.
-
-    Returns
-    -------
-    diff : np.ndarray
-        Array of normalized distances.
-    """
-    if isinstance(N, int):
-        N = (N, N)
-
-    if isinstance(width, int):
-        width = (width, width)
-
-    if len(N) != 2 or len(width) != 2:
-        raise ValueError(f"Invalid parameters. Got N={N} and width={width}.")
-
-    # The extra axis is required to use `cdist`
-    i0 = np.arange(N[0])[:, np.newaxis] / width[0]
-    i1 = np.arange(N[1])[:, np.newaxis] / width[1]
-
-    return cdist(i0, i1, metric="euclidean")
-
-
-def gaussian_kernel(N: int | tuple, width: int | tuple, alpha: float, **kwargs):
+def gaussian_kernel(
+    N: int | tuple | np.ndarray, width: int | float | tuple, alpha: float, **kwargs
+):
     """Return a gaussian kernel.
 
     Parameters
@@ -153,7 +93,11 @@ def gaussian_kernel(N: int | tuple, width: int | tuple, alpha: float, **kwargs):
 
 
 def rational_kernel(
-    N: int | tuple, width: int | tuple, alpha: float, a: float, **kwargs
+    N: int | tuple | np.ndarray,
+    width: int | float | tuple,
+    alpha: float,
+    a: float,
+    **kwargs,
 ) -> np.ndarray:
     """Return a rational kernel.
 
@@ -185,7 +129,11 @@ def rational_kernel(
 
 
 def matern_kernel(
-    N: int | float, width: int | float, alpha: float, nu: float, **kwargs
+    N: int | tuple | np.ndarray,
+    width: int | float | tuple,
+    alpha: float,
+    nu: float,
+    **kwargs,
 ) -> np.ndarray:
     """Return a matern kernel.
 
@@ -222,13 +170,60 @@ def matern_kernel(
     dist = euclidean_difference_kernel(N, width)
 
     if nu == 1.5:
-        C = np.sqrt(3) * dist
-        C = (1.0 + C) * np.exp(-C)
+        dist *= np.sqrt(3)
+        C = 1.0 + dist
+        C *= np.exp(-dist)
     elif nu == 2.5:
-        C = np.sqrt(5) * dist
-        C = (1.0 + C + C**2 / 3.0) * np.exp(-C)
+        dist *= np.sqrt(5)
+        C = 1.0 + dist + dist**2 / 3.0
+        C *= np.exp(-dist)
 
-    return (alpha**2) * C
+    # Scale
+    C *= alpha**2
+
+    return C
+
+
+def periodic_kernel(
+    N: int | tuple | np.ndarray,
+    width: int | float | tuple,
+    alpha: float,
+    p: float,
+    **kwargs,
+) -> np.ndarray:
+    """Return a periodic kernel, aka Exp-Sine-Squared.
+
+    Parameters
+    ----------
+    N
+        Number of samples over which to generate the kernel.
+        If this is a length-2 tuple, assume that this is a
+        correlation between two different sets of indices.
+    width
+        Width of the kernel.
+    alpha
+        Square root of the kernel variance.
+    p
+        Periodicity of the kernel.
+    kwargs : dict
+        Unused keyword arguemnts, required for compatibilty
+        when calling with `get_kernel`.
+
+    Returns
+    -------
+    C : np.ndarray
+        Periodic covariance matrix of shape (N[0], N[1]). If
+        N is an integer, the covariance is square with shape (N, N).
+    """
+    dist = euclidean_difference_kernel(N, width)
+
+    C = np.sin(np.pi * dist / p)
+    C = np.exp(-2 * C**2)
+
+    # Scale
+    C *= alpha**2
+
+    return C
 
 
 def moving_average_inverse_kernel(
@@ -274,3 +269,204 @@ def moving_average_inverse_kernel(
     IW = np.identity(N) - W
 
     return alpha * (IW.T @ IW)
+
+
+# ==================
+# Distance functions
+# ==================
+
+
+def squared_difference_kernel(
+    N: int | tuple | np.ndarray, width: int | float | tuple
+) -> np.ndarray:
+    """Create a distance matrix for a kernel using squared difference.
+
+    N : int | tuple
+        Number of samples over which to generate the kernel.
+        If this is a length-2 tuple, assume that this is a
+        correlation between two different sets of indices.
+    width : int | tuple
+        Width of the kernel along each axis. For a gaussian,
+        this is the standard deviation.
+
+    Returns
+    -------
+    diff : np.ndarray
+        Array of normalized distances.
+    """
+    # If only a single integer is provided, assume
+    # a square covariance matrix
+    if isinstance(N, int | np.ndarray):
+        N = (N, N)
+
+    if isinstance(width, int | float):
+        width = (width, width)
+
+    if len(N) != 2 or len(width) != 2:
+        raise ValueError(f"Invalid parameters. Got N={N} and width={width}.")
+
+    i0 = np.arange(N[0]) if isinstance(N[0], int) else N[0]
+    i1 = np.arange(N[1]) if isinstance(N[1], int) else N[1]
+
+    i0 = i0 / width[0]
+    i1 = i1 / width[1]
+
+    return np.subtract.outer(i0, i1) ** 2
+
+
+def euclidean_difference_kernel(
+    N: int | tuple | np.ndarray, width: int | float | tuple
+) -> np.ndarray:
+    """Create a distance matrix for a kernel using euclidean difference.
+
+    N : int | tuple
+        Number of samples over which to generate the kernel.
+        If this is a length-2 tuple, assume that this is a
+        correlation between two different sets of indices.
+    width : int | tuple
+        Width of the kernel along each axis. For a gaussian,
+        this is the standard deviation.
+
+    Returns
+    -------
+    diff : np.ndarray
+        Array of normalized distances.
+    """
+    if isinstance(N, int | np.ndarray):
+        N = (N, N)
+
+    if isinstance(width, int | float):
+        width = (width, width)
+
+    if len(N) != 2 or len(width) != 2:
+        raise ValueError(f"Invalid parameters. Got N={N} and width={width}.")
+
+    i0 = np.arange(N[0]) if isinstance(N[0], int) else N[0]
+    i1 = np.arange(N[1]) if isinstance(N[1], int) else N[1]
+
+    i0 = i0 / width[0]
+    i1 = i1 / width[1]
+
+    return cdist(i0[:, np.newaxis], i1[:, np.newaxis], metric="euclidean")
+
+
+# =========
+# Utilities
+# =========
+
+
+def is_hermitian_positive_definite(x: np.ndarray) -> bool:
+    """Check if a matrix is Hermitian positive-definite.
+
+    Parameters
+    ----------
+    x
+        Array to check.
+
+    Returns
+    -------
+    result
+        True if `x` is hermitian positive-definite
+    """
+    if not la.ishermitian(x):
+        return False
+
+    try:
+        la.cholesky(x, lower=False)
+    except la.LinAlgError:
+        return False
+
+    return True
+
+
+def convert_band_diagonal(
+    x: np.ndarray, tol: float = 1.0e-8, which: str = "full"
+) -> np.ndarray:
+    """Convert a full band diagonal kernel into just the lower band.
+
+    Used to feed into `la.solveh_banded.`
+
+    Parameters
+    ----------
+    x
+        `n x n` symmetric band-diagonal matrix
+    tol
+        Smallest value to consider when finding the
+        band edge. Default is 1.0e-5.
+    which
+        Which band to extract. Options are
+        {"lower", "upper", "full"}. Default is "full".
+
+    Returns
+    -------
+    xb
+        Band diagonal matrix of shape (n,u+l+1), (n,u+1), or (n,l+1)
+    """
+    if which == "full":
+        return _bd_sym(x, tol)
+    if which in {"upper", "lower"}:
+        return _bd_sym_ul(x, tol, lower=which == "lower")
+
+    raise ValueError(
+        f"Got invalid argument `which`={which}. "
+        "Only `full`, `upper`, or `lower` are accepted."
+    )
+
+
+def _bd_sym(x: np.ndarray, tol: float) -> np.ndarray:
+    """Full band of a symmetric band-diagonal matrix."""
+    N = x.shape[0]
+    M = np.sum(x > tol, axis=-1).max() // 2 + 1
+
+    banded = np.zeros((2 * M - 1, N), dtype=x.dtype)
+
+    banded[M - 1 :] = _bd_sym_ul(x, tol, lower=True)
+    banded[: M - 1] = _bd_sym_ul(x, tol, lower=False)[1:]
+
+    return banded
+
+
+def _bd_sym_ul(x: np.ndarray, tol: float, lower: bool = False) -> np.ndarray:
+    """Upper or lower band of a symmetric band-diagonal matrix.
+
+    Should be symmetric positive-definite.
+    """
+    N = x.shape[0]
+    M = np.sum(x > tol, axis=-1).max() // 2 + 1
+
+    banded = np.zeros((M, N), dtype=x.dtype)
+
+    for ii in range(M):
+        if lower:
+            banded[ii, : N - ii] = x.diagonal(ii)
+        else:
+            banded[-ii, ii:] = x.diagonal(-ii)
+
+    return banded
+
+
+def _get_band_inds(R: np.ndarray, tol: float = 1.0e-4) -> tuple:
+    """Get the indices of the band edge for a band diagonal matrix.
+
+    Parameters
+    ----------
+    R
+        Band diagonal matrix
+    tol
+        Cutoff threshold to consider values to be
+        outside of the main band.
+
+    Returns
+    -------
+    start_ind : np.ndarray[int]
+        left indices of the band.
+    end_ind : np.ndarray[int]
+        right indices of the band.
+    """
+    u = abs(R) > tol
+
+    start_ind = np.argmax(u, axis=-1)
+    end_ind = R.shape[-1] - np.argmax(u[..., ::-1], axis=-1)
+    end_ind[~np.any(u, axis=-1)] = 0
+
+    return start_ind.astype(np.int32), end_ind.astype(np.int32)

--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -72,7 +72,7 @@ def band_wiener(R, Ni, Si, y, bw):
         Ni_ki = Ni[ki].astype(np.float64)
 
         # Calculate the Wiener noise weighting (i.e. inverse covariance)
-        Ci = _fast_tools._band_wiener_covariance(R, Ni_ki, start_ind, end_ind, bw)
+        Ci = _fast_tools._linear_covariance_banded(R, Ni_ki, start_ind, end_ind, bw)
 
         # Set the noise estimate before adding in the signal contribution. This avoids
         # the issue that the inverse-noise estimate becomes non-zero even when the data

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,13 @@ from setuptools import Extension, setup
 # Enable OpenMP support if available
 if re.search("gcc", sysconfig.get_config_var("CC")) is None:
     print("Not using OpenMP")
-    omp_args = []
+    OMP_ARGS = []
 else:
-    omp_args = ["-fopenmp"]
+    OMP_ARGS = ["-fopenmp"]
+
+# Subset of `-ffast-math` compiler flags which should
+# preserve IEEE compliance
+FAST_MATH_ARGS = ["-O3", "-fno-math-errno", "-fno-trapping-math", "-march=native"]
 
 # Cython module for fast operations
 extensions = [
@@ -24,15 +28,15 @@ extensions = [
         "draco.util._fast_tools",
         ["draco/util/_fast_tools.pyx"],
         include_dirs=[np.get_include()],
-        extra_compile_args=omp_args,
-        extra_link_args=omp_args,
+        extra_compile_args=[*FAST_MATH_ARGS, *OMP_ARGS],
+        extra_link_args=[*FAST_MATH_ARGS, *OMP_ARGS],
     ),
     Extension(
         "draco.util.truncate",
         ["draco/util/truncate.pyx"],
         include_dirs=[np.get_include()],
-        extra_compile_args=omp_args,
-        extra_link_args=omp_args,
+        extra_compile_args=OMP_ARGS,
+        extra_link_args=OMP_ARGS,
     ),
 ]
 


### PR DESCRIPTION
Implements a simple GP interpolator for resampling, and a task to use this as a sidereal regridder.

This PR makes a handful of minor changes to the structure of the `Regridder` code, but I think I've managed to avoid any impacts on end users. One point of note is that I've updated the various `SiderealRegridder` tasks to take a `SiderealStream` as input.

# Main changes
## `kernels.py`
- Updated to support sample values as inputs, rather than just a range
- Added a periodic kernel
- Added helpers for getting the main band of a band-diagonal kernel

## `gaussian_process.py`
Implements GP resampling/interpolation. The main functions are:
#### `interpolate_unweighted`
- Interpolates signal + noise and propagates weights

#### `_select_interp_samples`
Figures out which samples we can interpolate onto, based solely on the initial mask and the width of the kernel.

## `_fast_tools.pyx`
- Adds a `_banded_matmul` function, which is quite a bit faster than `np.matmul` when the band is fairly narrow.

There's also a small bug fix, and I've added extra compiler flags to `_fast_tools.pyx` in hopes of improving their performance a bit.