### PR TITLE
docs(powerspec): clean up comments and docstrings

### DIFF
--- a/draco/analysis/powerspec.py
+++ b/draco/analysis/powerspec.py
@@ -30,10 +30,10 @@ class TransformJyPerBeamToKelvin(task.SingleTask):
     in_place : bool
         If True, modify in place and return the input container.
     ncyl : int
-      number of cylinders to include in the maximum baseline estimate
-      Note that, this should be equal to the numbers used to make the actual map.
-      Default is 3, i.e, the map is made with all the east-west baselines.
-      ncyl = 0 means that map is made with intracylinder baselines only.
+        Number of cylinders to include in the maximum baseline estimate.
+        Note that this should be equal to the numbers used to make the actual map.
+        Default is 3, i.e, the map is made with all the east-west baselines.
+        ncyl = 0 means that map is made with intracylinder baselines only.
     """
 
     in_place = config.Property(proptype=bool, default=True)
@@ -62,7 +62,8 @@ class TransformJyPerBeamToKelvin(task.SingleTask):
 
         Returns
         -------
-        delay spectrum : containers.DelayTransform
+        out_map : containers.RingMap
+            Ringmap in Kelvin.
         """
         rm.redistribute("freq")
 
@@ -454,11 +455,11 @@ class SpatialTransformDelayMap(task.SingleTask):
         Here "tukey-0.5" means 0.5 is the fraction of the full window that
         will be tapered.
     ew_min : float
-     Minimum east-west baseline in meter.
+        Minimum east-west baseline in meter.
     ew_max : float
-      Maximum east-west baseline in meter.
+        Maximum east-west baseline in meter.
     ns_bl : float
-      basline along north-south direction to include.
+        Maximum north-south baseline in meter.
     """
 
     apply_spatial_window = config.Property(proptype=bool, default=True)
@@ -486,7 +487,7 @@ class SpatialTransformDelayMap(task.SingleTask):
         Parameters
         ----------
         telescope : TransitTelescope
-            The telescope object to use
+            The telescope object to use.
         """
         self.tel = io.get_telescope(telescope)
         self.cosmology = get_cosmo()
@@ -497,12 +498,12 @@ class SpatialTransformDelayMap(task.SingleTask):
         Parameters
         ----------
         ds : containers.DelayTransform
-          The delay map, whose spatial transform will be estimated.
+            The delay map, whose spatial transform will be estimated.
 
         Returns
         -------
         spatial cube : containers.SpatialDelayCube
-           The data cube in (delay,u,v) domain.
+            The data cube in (delay,u,v) domain.
         """
         if not isinstance(ds, containers.DelayTransform):
             raise ValueError(
@@ -606,13 +607,12 @@ class SpatialTransformDelayMap(task.SingleTask):
 
 
 class CrossPowerSpectrum3D(task.SingleTask):
-    """Estimate the 3D cross power spectrum of two data cubes .
+    """Estimate the 3D cross power spectrum of two data cubes.
 
-    This estimates the 3D cross power spectrum of two data cubes by taking
-    real part of correlation between two complex data cubes and normalize that
-    by the volume of the data cube in Mpc^3. The unit of the output power spectrum
-    is K^2Mpc^3.
-
+    This estimates the 3D cross power spectrum of two data cubes by taking the
+    real part of correlation between two complex data cubes and normalizing that
+    by the volume of the data cube in h^-3 Mpc^3. The unit of the output power spectrum
+    is K^2 h^-3 Mpc^3.
     """
 
     def process(self, vis_1, vis_2):
@@ -621,14 +621,14 @@ class CrossPowerSpectrum3D(task.SingleTask):
         Parameters
         ----------
         vis_1 : containers.SpatialDelayCube
-          The 1st data cube in fourier domain.
+            The 1st data cube in fourier domain.
         vis_2 : containers.SpatialDelayCube
-          The 2nd data cube in fourier domain.
+            The 2nd data cube in fourier domain.
 
         Returns
         -------
         cross_ps : containers.PowerSpectrum3D
-           The 3D cross power spectum.
+            The 3D cross power spectum.
         """
         # Validate the shapes of two data cubes match
         if vis_1.vis.shape != vis_2.vis.shape:
@@ -654,7 +654,7 @@ class CrossPowerSpectrum3D(task.SingleTask):
         pol = np.array(["-".join([p1, p2]) for p1 in pol_1 for p2 in pol_2])
 
         # Compute power spectrum normalization factor
-        # this is the survey volume, corrected  for the
+        # this is the survey volume, corrected for the
         # tapering window function used for FFT
         volume_cube = vis_1.attrs["volume"]
         if vis_1.attrs["window_los"] != "None" and vis_2.attrs["window_los"] != "None":
@@ -726,12 +726,12 @@ class AutoPowerSpectrum3D(CrossPowerSpectrum3D):
         Parameters
         ----------
         data : containers.SpatialDelayCube
-           The  data cube in fourier domain.
+            The data cube in Fourier domain.
 
         Returns
         -------
         auto_ps : containers.PowerSpectrum3D
-           The 3D auto power spectum.
+            The 3D auto power spectum.
         """
         return super().process(data, data)
 
@@ -745,16 +745,20 @@ class CylindricalPowerSpectrum2D(task.SingleTask):
     Attributes
     ----------
     bl_min : float
-       The minimum baseline length in meter to include in power spectrum binning. Default: 20.0m
+        The minimum baseline length in meter to include in power spectrum
+        binning. Default: 20.0m
     bl_max : float
-       The minimum baseline length in meter to include in power spectrum binning. Default: 66.0m
+        The minimum baseline length in meter to include in power spectrum
+        binning. Default: 66.0m
     Nbins_2D : int
-       The number of bins in 2D cylindrical binning. Default: 35
+        The number of bins in 2D cylindrical binning. Default: 35.
     logbins_2D : bool, optional
-        If True, use logarithmic binning in cylindrical averaging. Default: False
+        If True, use logarithmic binning in cylindrical averaging.
+        Default: False.
     delay_cut : float
-        Throw away the delay modes below this cutoff during spherical averaging, unit sec.
-        This is same for both polarization. Default: 300.0e-9
+        Throw away the delay modes below this cutoff during spherical
+        averaging, unit sec.
+        This is same for both polarizations. Default: 300.0e-9.
     """
 
     bl_min = config.Property(proptype=float, default=20.0)
@@ -783,12 +787,12 @@ class CylindricalPowerSpectrum2D(task.SingleTask):
         Parameters
         ----------
         ps : containers.PowerSpectrum3D
-          The 3D power spectrum cube.
+            The 3D power spectrum cube.
 
         Returns
         -------
         cross_ps : containers.PowerSpectrum2D
-           The 2D power spectum.
+            The 2D power spectum.
         """
         if not isinstance(ps, containers.PowerSpectrum3D):
             raise ValueError(
@@ -924,7 +928,7 @@ class SphericalPowerSpectrum2Dto1D(task.SingleTask):
     Attributes
     ----------
     Nbins_3D : int
-       The number of bins in 3D spherical binning. Default: 8
+        The number of bins in 3D spherical binning. Default: 8
     logbins_3D : bool, optional
         If True, use logarithmic binning in cylindrical averaging. Default: False
 
@@ -939,12 +943,12 @@ class SphericalPowerSpectrum2Dto1D(task.SingleTask):
         Parameters
         ----------
         ps2D : containers.PowerSpectrum2D
-          The 2D cylindrically averaged power spectrum.
+            The 2D cylindrically averaged power spectrum.
 
         Returns
         -------
         ps1D : containers.PowerSpectrum1D
-           The 1D power spectum.
+            The 1D power spectum.
         """
         if not isinstance(ps2D, containers.PowerSpectrum2D):
             raise ValueError(
@@ -1004,15 +1008,19 @@ class SphericalPowerSpectrum3Dto1D(task.SingleTask):
     Attributes
     ----------
     bl_min : float
-       The minimum baseline length in meter to include in power spectrum binning. Default: 20.0
+        The minimum baseline length in meter to include in power spectrum
+        binning. Default: 20.0
     bl_max : float
-       The minimum baseline length in meter to include in power spectrum binning. Default: 66.0
+        The minimum baseline length in meter to include in power spectrum
+        binning. Default: 66.0
     Nbins_3D : int
-       The number of bins in 3D spherical binning. Default: 8
+        The number of bins in 3D spherical binning. Default: 8
     logbins_3D : bool, optional
-        If True, use logarithmic binning in cylindrical averaging. Default: False
+        If True, use logarithmic binning in cylindrical averaging.
+        Default: False
     delay_cut : float
-        Throw away the delay modes below this cutoff during spherical averaging, unit sec.
+        Throw away the delay modes below this cutoff during spherical
+        averaging, unit sec.
         This is same for both polarization. Default: 300.0e-9
     """
 
@@ -1041,12 +1049,12 @@ class SphericalPowerSpectrum3Dto1D(task.SingleTask):
         Parameters
         ----------
         ps : containers.PowerSpectrum3D
-          The 3D power spectrum cube.
+            The 3D power spectrum cube.
 
         Returns
         -------
         ps1D : containers.PowerSpectrum1D
-           The 1D power spectum.
+            The 1D power spectum.
         """
         if not isinstance(ps, containers.PowerSpectrum3D):
             raise ValueError(
@@ -1173,11 +1181,11 @@ def f2z(freq):
     Parameters
     ----------
     freq : float
-      frequency in MHz
+        Frequency in MHz.
 
     Returns
     -------
-    redshift: float
+    redshift : float
     """
     return units.nu21 / freq - 1
 
@@ -1188,12 +1196,12 @@ def z2f(z):
     Parameters
     ----------
     z : float
-     redshift
+        Redshift.
 
     Returns
     -------
     frequency: float
-       frequency in MHz
+        Frequency in MHz.
     """
     return units.nu21 / (z + 1)
 
@@ -1204,13 +1212,14 @@ def dRperp_dtheta(z, cosmo=None):
     Parameters
     ----------
     z : float
-     redshift
-    cosmo: Cosmology object
+        Redshift.
+    cosmo : Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
-    comoving transverse distance: float. unit in [h^-1 Mpc].
+    distance : float
+        Comoving distance conversion factor, in [h^-1 Mpc rad^-1].
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1223,13 +1232,14 @@ def dRpara_df(z, cosmo=None):
     Parameters
     ----------
     z : float
-     redshift
+        Redshift.
     cosmo: Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
-    Radial comoving distance: float. unit in [h^-1 Mpc]
+    distance : float
+        Comoving distance conversion factor, in [h^-1 Mpc Hz^-1].
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1243,22 +1253,22 @@ def dRpara_df(z, cosmo=None):
 
 
 def delays_to_kpara(delay, z, cosmo=None):
-    """Conver delay in sec unit to k_parallel (comoving h/Mpc along line of sight).
+    """Convert delay in sec unit to k_parallel (comoving h/Mpc along line of sight).
 
     Parameters
     ----------
     delay : np.array
-      The inteferometric delay observed in units second.
+        The inteferometric delay observed in units second.
     z : float
-      The redshift of the expected 21cm emission.
+        The redshift of the expected 21cm emission.
     cosmo: Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     kpara : np.array
-       The spatial fluctuation scale parallel to the line of sight probed by
-       the input delay (eta). Unit: [h/Mpc]
+        The spatial fluctuation scale parallel to the line of sight probed by
+        the input delay (eta). Unit: [h/Mpc]
     """
     # Eqn A10 of Liu,A 2014A
     return (delay * 2 * np.pi) / dRpara_df(z, cosmo=cosmo)
@@ -1270,7 +1280,7 @@ def kpara_to_delay(kpara, z, cosmo=None):
     Parameters
     ----------
     kpara : np.array
-      The spatial fluctuation scale parallel to the line of sight in unit [h/Mpc].
+        The spatial fluctuation scale parallel to the line of sight in unit [h/Mpc].
     z : float
         The redshift of the expected 21cm emission.
     cosmo: Cosmology object
@@ -1279,8 +1289,8 @@ def kpara_to_delay(kpara, z, cosmo=None):
     Returns
     -------
     delay : np.array
-      The inteferometric delay in unit second
-      which probes the spatial scale given by kpara.
+        The inteferometric delay in unit second
+        which probes the spatial scale given by kpara.
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1320,17 +1330,17 @@ def kperp_to_u(kperp, z, cosmo=None):
     Parameters
     ----------
     kperp : np.array
-      The spatial fluctuation scale perpendicular to the line of sight. Unit: [h/Mpc]
+        The spatial fluctuation scale perpendicular to the line of sight. Unit: [h/Mpc]
     z : float
         The redshift of the expected 21cm emission.
-    cosmo: Cosmology object
+    cosmo : Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     u : np.array
-     The baseline separation of two interferometric antennas in units of
-     wavelength which probes the spatial scale given by kperp.
+        The baseline separation of two interferometric antennas in units of
+        wavelength which probes the spatial scale given by kperp.
 
     """
     if cosmo is None:
@@ -1349,14 +1359,14 @@ def jy_per_beam_to_kelvin(freq, bl_length):
     Parameters
     ----------
     freq : np.ndarray[freq]
-        frequency in MHz unit
+        Frequency in MHz unit.
     bl_length : float
-        baseline length in meter
+        Baseline length in meter.
 
     Returns
     -------
     C : np.ndarray[freq]
-     The conversion factor from Jy/beam to Kelvin
+        The conversion factor from Jy/beam to Kelvin.
     """
     Jy = 1.0e-26  # W m^-2 Hz^-1
     wl = units.c / (freq * 1e6)  # freq of the map in MHz
@@ -1381,7 +1391,7 @@ def noise_equivalent_bandwidth(N, window):
     Parameters
     ----------
     N: int
-     Size of the window
+        Size of the window.
     window : array_like
         A 1-Dimenaional array like.
 
@@ -1402,28 +1412,28 @@ def get_fourier_modes(ra, dec, delays, redshift, cosmo=None):
     Parameters
     ----------
     ra : np.array[nra]
-      The RA axis in deg unit.
+        The RA axis in deg unit.
     dec : np.narray[ndec]
-      The DEC axis in deg unit.
+        The DEC axis in deg unit.
     delays : np.array[ndelay]
-      The delay axis in second unit.
+        The delay axis in second unit.
     redshift : float
-      redshift at the centre of the band.
-    cosmo: Cosmology object
+        Redshift at the centre of the band.
+    cosmo : Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     kx : np.array[nra]
-      The Fourier modes conjugate to RA axis, unit [h/Mpc].
+        The Fourier modes conjugate to RA axis, unit [h/Mpc].
     ky : np.array[ndec]
-      The Fourier modes conjugate to DEC axis, unit [h/Mpc].
+        The Fourier modes conjugate to DEC axis, unit [h/Mpc].
     u : np.array[nra]
-      gridded u-coordinates
+        Gridded u-coordinates.
     v : np.array[nel]
-      gridded v-coordinates
+        Gridded v-coordinates.
     kpara : np.array[ndelay]
-      The Fourier modes conjugate to frequency axis, unit [h/Mpc].
+        The Fourier modes conjugate to frequency axis, unit [h/Mpc].
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1437,13 +1447,13 @@ def get_fourier_modes(ra, dec, delays, redshift, cosmo=None):
 
     DMz = dRperp_dtheta(redshift, cosmo=cosmo)  # in [h^-1 Mpc]
 
-    # Convert the RA and DEC resolution to Mpc unit
-    d_RA_Mpc = DMz * res_ra_radian * np.mean(np.cos(np.deg2rad(dec)))
-    d_DEC_Mpc = DMz * res_dec_radian
+    # Convert the RA and DEC resolution to h^-1 Mpc unit
+    d_RA_hinvMpc = DMz * res_ra_radian * np.mean(np.cos(np.deg2rad(dec)))
+    d_DEC_hinvMpc = DMz * res_dec_radian
 
     # Estimate the spatial Fourier modes
-    k_x = 2 * np.pi * np.fft.fftshift(np.fft.fftfreq(nra, d=d_RA_Mpc))
-    k_y = 2 * np.pi * np.fft.fftshift(np.fft.fftfreq(ndec, d=d_DEC_Mpc))
+    k_x = 2 * np.pi * np.fft.fftshift(np.fft.fftfreq(nra, d=d_RA_hinvMpc))
+    k_y = 2 * np.pi * np.fft.fftshift(np.fft.fftfreq(ndec, d=d_DEC_hinvMpc))
 
     # The gridded u and v coordinates
     u = kperp_to_u(k_x, redshift)
@@ -1461,18 +1471,18 @@ def image_to_uv(data, ra, dec, window="tukey-0.5"):
     Parameters
     ----------
     data : np.ndarray[ra,el]
-       The data, whose spatial FFT will be computed along RA and Dec axes.
+        The data, whose spatial FFT will be computed along RA and Dec axes.
     ra : np.array(ra)
-      RA of the map in degrees.
+        RA of the map in degrees.
     dec : np.array(dec)
-      Dec of the map in degrees.
+        Dec of the map in degrees.
     window: window available in :func:`draco.util.tools.window_generalised()`, optional
-       Apply an apodisation function. Default: 'tukey-0.5'.
+        Apply an apodisation function. Default: 'tukey-0.5'.
 
     Returns
     -------
-      data_cube : np.ndarray[kx,ky]
-         The 2D spatial FFT of the data cube in (kx,ky) or (u,v) domain.
+    data_cube : np.ndarray[kx,ky]
+        The 2D spatial FFT of the data cube in (kx,ky) or (u,v) domain.
     """
     # Find the Fourier norm for the FFT
     # The norm is mentioned here - https://numpy.org/doc/2.0/reference/routines.fft.html
@@ -1504,20 +1514,20 @@ def vol_normalization(ra, dec, freq, redshift, cosmo=None):
     Parameters
     ----------
     ra : np.array[ra]
-      The RA array in deg unit.
+        The RA array in deg unit.
     dec : np.narray[dec]
-      The DEC array in deg unit.
+        The DEC array in deg unit.
     freq : np.array[freq]
-      The freq array in MHz.
+        The freq array in MHz.
     redshift : float
-      redshift at the centre of the band.
-    cosmo: Cosmology object
+        Redshift at the centre of the band.
+    cosmo : Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     norm : float
-      The  Ppower spectrum normalization factor in Mpc^3 unit
+        The power spectrum normalization factor in h^-3 Mpc^3 unit.
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1533,16 +1543,16 @@ def vol_normalization(ra, dec, freq, redshift, cosmo=None):
     # Comoving distance
     DMz = dRperp_dtheta(redshift, cosmo=cosmo)  # in [h^-1 Mpc]
 
-    # Convert the RA and DEC resolution to Mpc unit
-    dx_Mpc = DMz * res_ra_radian * np.mean(np.cos(np.deg2rad(dec)))
-    dy_Mpc = DMz * res_dec_radian
-    Lx = nra * dx_Mpc  # survey length along RA [h^-1 Mpc]
-    Ly = ndec * dy_Mpc  # survey length along DEC [h^-1 Mpc]
+    # Convert the RA and DEC resolution to h^-1 Mpc unit
+    dx_hinvMpc = DMz * res_ra_radian * np.mean(np.cos(np.deg2rad(dec)))
+    dy_hinvMpc = DMz * res_dec_radian
+    Lx = nra * dx_hinvMpc  # survey length along RA [h^-1 Mpc]
+    Ly = ndec * dy_hinvMpc  # survey length along DEC [h^-1 Mpc]
 
-    ## Along line-of-sight direction
+    # Along line-of-sight direction
     chan_width = np.abs(np.diff(freq)).mean() * 1e6  # channel width in Hz
-    dz_Mpc = dRpara_df(redshift, cosmo=cosmo) * chan_width  # [h^-1 Mpc]
-    Lz = dz_Mpc * nfreq  # survey length along line-of-sight [Mpc]
+    dz_hinvMpc = dRpara_df(redshift, cosmo=cosmo) * chan_width  # [h^-1 Mpc]
+    Lz = dz_hinvMpc * nfreq  # survey length along line-of-sight [h^-1 Mpc]
 
     return Lx * Ly * Lz
 
@@ -1553,16 +1563,16 @@ def nanaverage(d, w, axis=None):
     Parameters
     ----------
     d : np.ndarray
-     The data to average
+        The data to average.
     w : np.ndarray
-     The weight to use during averaging.
+        The weight to use during averaging.
     axis: int, optional
-     Axis along which the average will be taken.
+        Axis along which the average will be taken.
 
     Returns
     -------
     d_avg : np.ndarray
-     The weighted average.
+        The weighted average.
     """
     return np.sum(d * w, axis=axis, where=~np.isnan(d)) / np.sum(w, axis=axis)
 
@@ -1582,28 +1592,28 @@ def spatial_mask(k_x, k_y, ew_min, ew_max, ns_bl, wl_min, wl_max, redshift, cosm
     Parameters
     ----------
     k_x : np.array[nra]
-      The Fourier modes conjugate to RA axis, unit Mpc^-1.
+        The Fourier modes conjugate to RA axis, unit h Mpc^-1.
     k_y : np.array[ndec]
-      The Fourier modes conjugate to DEC axis, unit Mpc^-1.
+        The Fourier modes conjugate to DEC axis, unit h Mpc^-1.
     ew_min : float
-     Minimum east-west baseline in meter.
+        Minimum east-west baseline in meter.
     ew_max : float
-      Maximum east-west baseline in meter.
+        Maximum east-west baseline in meter.
     ns_bl : float
-      basline along north-south direction to include.
+        Maximum north-south baseline in meter.
     wl_min : float
-      minimum wavelength in meter.
+        Minimum wavelength in meter.
     wl_max : float
-      maximum wavelength in meter.
+        Maximum wavelength in meter.
     redshift: float
-       redshift at the center of the band.
+        Redshift at the center of the band.
     cosmo: Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     fourier_mask : np.ndarray[u,v]
-      The  fourier mask in [u,v] or [kx,ky] domain
+        The Fourier mask in [u,v] or [kx,ky] domain.
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1644,16 +1654,16 @@ def get_3D_ps(data_cube_1, data_cube_2, vol_norm_factor):
     Parameters
     ----------
     data_cube_1 : np.ndarray[pol,delay,kx,ky]
-      complex data cube in (delay,kx,ky) domain.
+        Complex data cube in (delay,kx,ky) domain.
     data_cube_2 : np.ndarray[pol,delay,kx,ky]
-      complex data cube in (delay,kx,ky) domain.
+        Complex data cube in (delay,kx,ky) domain.
     vol_norm_factor : float
-      power spectrum normalization factor in [Mpc^3]
+        Power spectrum normalization factor in [h^-3 Mpc^3].
 
     Returns
     -------
     ps_cube_real: np.ndarray[pol,delay,kx,ky]
-       The real part of the power spectrum
+        The real part of the power spectrum.
     """
     if data_cube_1 is None and data_cube_2 is None:
         raise NameError("Atleast one data cube must be provided")
@@ -1677,24 +1687,24 @@ def reshape_data_cube(data_cube, u, v, bl_min, bl_max):
     Parameters
     ----------
     data_cube : np.ndarray[kx,ky]
-     The data cube to reshape and flatten.
+        The data cube to reshape and flatten.
     u : np.ndarray[kx]
-     The u-coordinates in wavelength unit.
+        The u-coordinates in wavelength unit.
     v : np.ndarray[ky]
-     The v-coordinates in wavelength unit.
+        The v-coordinates in wavelength unit.
     bl_min : float
-     The min baseline length in wavelength unit.
+        The min baseline length in wavelength unit.
     bl_max : float
-     The max baseline length in wavelength unit.
+        The max baseline length in wavelength unit.
 
     Returns
     -------
     ft_cube : np.ndarray[nvis]
-     The flatten data cube.
+        The flatten data cube.
     uu : np.ndarray[nvis]
-     The flatten u-coordinates
+        The flatten u-coordinates.
     vv : np.ndarray[nvis]
-     The flatten v-coordinates
+        The flatten v-coordinates.
     """
     g_uu, g_vv = np.meshgrid(v, u)
     g_ru = np.sqrt(g_uu**2 + g_vv**2)
@@ -1712,30 +1722,30 @@ def get_2d_ps(ps_cube, weight, kperp_bins, uu, vv, redshift, cosmo=None):
     Parameters
     ----------
     ps_cube : np.ndarray[nbl]
-      The power spectrum array to average in cylindrical bins.
+        The power spectrum array to average in cylindrical bins.
     weight : np.ndarray[nbl]
-      The weight to be used in averaging.
-       If None, then use unit unifrom weight.
+        The weight to be used in averaging.
+        If None, then use unit unifrom weight.
     kperp_bins : float
-      The kperp values of each bin, at which the power spectrum will be
-       calculated. Unit: Mpc^-1
+        The kperp values of each bin, at which the power spectrum will be
+        calculated. Unit: h Mpc^-1
     uu : np.ndarray[u]
-      The flatten u-coordinate in wavelength.
+        The flattened u-coordinate in wavelength.
     vv : np.ndarray[v]
-      The flatten v-coordinate in wavelength.
+        The flattened v-coordinate in wavelength.
     redshift : float
-      The redshift corresponding to the band center.
-    cosmo: Cosmology object
+        The redshift corresponding to the band center.
+    cosmo : Cosmology object
         Default is cora.util.Cosmology() default.
 
     Returns
     -------
     ps_2D : np.ndarray[kperp]
-      The  binned  power along k_perp (cylindrical binning).
+        The binned power along k_perp (cylindrical binning).
     ps_2D_w : np.ndarray[kperp]
-      The binned  weight along k_perp (cylindrical binning).
+        The binned weight along k_perp (cylindrical binning).
     n_eff : np.ndarray[kperp]
-       The effective number of modes present in each bin.
+        The effective number of modes present in each bin.
     """
     if cosmo is None:
         cosmo = get_cosmo()
@@ -1783,33 +1793,33 @@ def get_1d_ps(
     Parameters
     ----------
     ps_2D :  np.ndarray[kpara,kperp]
-     The cylindrically averaged 2D power spectrum.
+        The cylindrically averaged 2D power spectrum.
     kperp : np.array[kperp]
-     The k_perp array after cylindrically binning.
+        The k_perp array after cylindrically binning.
     kpara : np.array[kpara]
-     The k_parallel array.
+        The k_parallel array.
     weight_cube :  np.ndarray[kpara,kperp]
-      The weight array to use during spherical averaging.
+        The weight array to use during spherical averaging.
     signal_window :  np.ndarray[kpara,kperp]
-      The signal window mask.
+        The signal window mask.
     Nbins_3D : int
-      The number of 3D bins
+        The number of 3D bins.
     logbins_3D : bool
-      Bin in logarithmic space if True.
+        Bin in logarithmic space if True.
 
     Returns
     -------
     k1d: np.array[Nbins_3d]
-      The K-values corresponding to the bin center
+        The K-values corresponding to the bin center.
     ps_3D: np.array[Nbins_3d]
-     The spherically avg power spectrum.
+        The spherically avg power spectrum.
     ps_3D_err: np.array[Nbins_3d]
-      The error in the PS (sample variance)
+        The error in the PS (sample variance)
     variance: np.array[Nbins_3d]
-      The variance in the power spectrum
-      estimated from thermal noise.
+        The variance in the power spectrum
+        estimated from thermal noise.
     n_eff: np.array[Nbins_3d]
-      Effective number of modes in each bin.
+        Effective number of modes in each bin.
     """
     # Estimate the 1D k-modes
     kpp, kll = np.meshgrid(kperp, kpara)


### PR DESCRIPTION
Some comments and docstrings still incorrectly referred to Mpc units, when everything is now computed consistently in h^-1 Mpc units. Those are all corrected now, and a few variable names have been altered to avoid confusion (e.g. `d_RA_Mpc` -> `d_RA_hinvMpc`. Also, docstring formatting has overall been cleaned up to have more uniform style.