### PR TITLE
build(pyproject): add dnspython to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "caput[compression,fftw] @ git+https://github.com/radiocosmology/caput.git",
     "cora @ git+https://github.com/radiocosmology/cora.git",
     "cython>0.18",
+    "dnspython",
     "driftscan @ git+https://github.com/radiocosmology/driftscan.git",
     "mpi4py",
     "numpy>=1.24",


### PR DESCRIPTION
I think this gives a dependency on `dnspython`
https://github.com/radiocosmology/draco/blob/7307bfb2b3a613daddb8ecc73069ca2efd8b0004/draco/core/misc.py#L376