### PR TITLE
Split Stokes I mask into separate tasks

### DIFF
--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -487,7 +487,7 @@ class DayenuDelayFilterHybridVis(task.SingleTask):
         # Extract the required axes
         freq = stream.freq[:]
 
-        npol, nfreq, new, nel, ntime = stream.vis.local_shape
+        npol, _, new, _, ntime = stream.vis.local_shape
 
         # Dereference the required datasets
         vis = stream.vis[:].local_array
@@ -515,7 +515,7 @@ class DayenuDelayFilterHybridVis(task.SingleTask):
 
                 # Construct the filter
                 try:
-                    NF, index = delay_filter(
+                    NF, _ = delay_filter(
                         freq,
                         flagx,
                         tau_width=self.tauw,
@@ -654,7 +654,7 @@ class ApplyDelayFilterHybridVis(task.SingleTask):
         hv.redistribute(["ra", "time"])
         source.redistribute(["ra", "time"])
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, _, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -13,7 +13,9 @@ import warnings
 from typing import ClassVar, overload
 
 import numpy as np
-from caput import config, mpiarray, weighted_median
+import numpy.typing as npt
+from caput import config, fftw, weighted_median
+from caput.mpiarray import MPIArray
 from cora.util import units
 from scipy.signal import convolve, firwin, oaconvolve
 from scipy.spatial.distance import cdist

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1895,7 +1895,7 @@ class RFISensitivityMask(task.SingleTask):
             madtimes = self._combine_st_mad_hook(sensitivity.time, freq)
 
         # Create arrays to hold final masks
-        nfreq, nlocal, ntime = radiometer.shape
+        nfreq, _, ntime = radiometer.shape
 
         finalmask = MPIArray((npol, nfreq, ntime), axis=0, dtype=bool)
         finalmask[:] = False
@@ -2743,7 +2743,7 @@ class TaperDelayTransform(task.SingleTask):
         else:
             taper = np.all(~apply.mask[:].local_array, axis=1).transpose(0, 2, 1)
 
-        npol, nel, nra = taper.shape
+        _, _, nra = taper.shape
 
         # Check that the axes match
         for dax, tax in [("sample", "ra"), ("el", "el")]:

--- a/draco/analysis/hyforesbandpass.py
+++ b/draco/analysis/hyforesbandpass.py
@@ -121,7 +121,7 @@ class DelayFilterHyFoReSBandpassHybridVis(task.SingleTask):
         if not np.array_equal(source.ra, hv.ra):
             raise ValueError("Right Ascension do not match for hybrid visibilities.")
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array
@@ -401,7 +401,7 @@ class DelayFilterHyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVi
         if not np.array_equal(source.ra, hv.ra):
             raise ValueError("Right Ascension do not match for hybrid visibilities.")
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array.copy()
@@ -630,7 +630,7 @@ class HyFoReSBandpassHybridVis(DelayFilterHyFoReSBandpassHybridVis):
         hv.redistribute(["ra", "time"])
         pf_hv.redistribute(["ra", "time"])
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array.copy()
@@ -793,7 +793,7 @@ class HyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVis):
         pf_hv.redistribute(["ra", "time"])
         maskf.redistribute(["ra", "time"])
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array.copy()
@@ -968,7 +968,7 @@ class HyFoReSBandpassHybridVisMaskKeepSource(DelayFilterHyFoReSBandpassHybridVis
         maskf.redistribute(["ra", "time"])
         masksf.redistribute(["ra", "time"])
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Dereference the required datasets
         vis = hv.vis[:].local_array.copy()
@@ -1183,7 +1183,7 @@ class DelayFilterHyFoReSBandpassHybridVisClean(task.SingleTask):
         hv.redistribute(["ra", "time"])
         source.redistribute(["ra", "time"])
 
-        npol, nfreq, new, nel, ntime = hv.vis.local_shape
+        npol, nfreq, new, _, ntime = hv.vis.local_shape
 
         # Compensate the window for the estimated bandpass gains
         y = bp.bandpass[:]
@@ -1207,7 +1207,7 @@ class DelayFilterHyFoReSBandpassHybridVisClean(task.SingleTask):
                 for xx in range(new):
 
                     # save the singular values for debugging or inspection
-                    u, s_val[pp, xx], vh = la.svd(W[pp, xx, :, :])
+                    s_val[pp, xx] = la.svd(W[pp, xx, :, :], compute_uv=False)
                     # TODO: use la.solve(W, y)
                     W_pinv[pp, xx, :, :], rank[pp, xx] = la.pinv(
                         W[pp, xx, :, :], atol=self.cutoff, return_rank=True

--- a/draco/analysis/powerspec.py
+++ b/draco/analysis/powerspec.py
@@ -109,7 +109,7 @@ class TransformJyPerBeamToKelvin(task.SingleTask):
             self.telescope.feedpositions[prod["input_a"], :]
             - self.telescope.feedpositions[prod["input_b"], :]
         )
-        xind, yind, dx, dy = find_grid_indices(baselines)
+        xind = find_grid_indices(baselines)[0]
         baslines = baselines[xind <= self.ncyl]
         bl = np.sqrt(np.sum(baslines**2, axis=-1))
         return bl.max()
@@ -401,7 +401,7 @@ class ApplyWienerDelayTransform(task.SingleTask):
         data.redistribute("ra")
         operator.redistribute("ra")
 
-        npol, nfreq, nra, nel = data.weight[:].local_shape
+        npol, _, nra, nel = data.weight[:].local_shape
 
         # Create the output container
         out = containers.DelayTransform(

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -1678,7 +1678,7 @@ class ReconstructVisFreqCov(ReconstructVisNoiseBase):
         weight_out = out.weight[:].local_array
         weight_out[:] = 0.0
 
-        npol, nfreq, nfreqs, new, nra = cov_in.shape
+        npol, nfreq, _, new, nra = cov_in.shape
 
         # Construct the noise factor.  Shape is (pol, freq, freq_sum, ew).
         noise_factor = np.empty(cov_in.shape[:-1], dtype=float)

--- a/draco/analysis/sensitivity.py
+++ b/draco/analysis/sensitivity.py
@@ -51,7 +51,7 @@ class ComputeSystemSensitivity(task.SingleTask):
         # Ensure we are distributed over frequency. Get shape of visibilities.
         data.redistribute("freq")
 
-        nfreq, nstack, ntime = data.vis.local_shape
+        nfreq, _, ntime = data.vis.local_shape
 
         # Extract the input flags.  If container has a gain dataset,
         # then also check for the default gain 1.0 + 0.0j as this indicates

--- a/draco/analysis/svdfilter.py
+++ b/draco/analysis/svdfilter.py
@@ -49,7 +49,7 @@ class SVDSpectrumEstimator(task.SingleTask):
             )
             mask_m = weight_m == 0.0
 
-            u, sig, vh = svd_em(vis_m, mask_m, niter=self.niter)
+            _, sig, _ = svd_em(vis_m, mask_m, niter=self.niter)
 
             spec.spectrum[m] = sig
 

--- a/draco/synthesis/stream.py
+++ b/draco/synthesis/stream.py
@@ -67,9 +67,7 @@ class SimulateSidereal(task.SingleTask):
         nfreq = tel.nfreq
         npol = tel.num_pol_sky
 
-        lfreq, sfreq, efreq = mpiutil.split_local(nfreq)
-
-        lm, sm, em = mpiutil.split_local(mmax + 1)
+        lfreq = mpiutil.split_local(nfreq)[0]
 
         # Set the minimum resolution required for the sky.
         ntime = 2 * mmax + 1

--- a/draco/util/filters.py
+++ b/draco/util/filters.py
@@ -1,0 +1,208 @@
+"""Utility functions for filtering data.
+
+Includes implementations of median filtering and high-pass filtering.
+"""
+
+import numpy as np
+import numpy.typing as npt
+from caput import tools, weighted_median
+from scipy import linalg as la
+from scipy import signal
+
+from .tools import window_generalised
+
+__all__ = [
+    "highpass_weighted_convolution_filter",
+    "lowpass_weighted_convolution_filter",
+    "medfilt",
+    "null_filter",
+]
+
+
+def lowpass_weighted_convolution_filter(
+    data: npt.NDArray[np.floating | np.complexfloating],
+    weight: npt.NDArray[np.floating | np.complexfloating],
+    samples: npt.NDArray[np.floating | np.complexfloating],
+    cutoff: float,
+    axis: int = -1,
+) -> np.ndarray[np.floating | np.complexfloating]:
+    """Apply a low-pass weighted convolution filter along an axis.
+
+    Parameters
+    ----------
+    data
+        The data to filter.
+    weight
+        The weights to apply.
+    samples
+        The sample times.
+    cutoff
+        The cutoff frequency.
+    axis
+        The axis to apply the filter along.
+    """
+    # Broadcast the kernel to the right dimension
+    bcast_sl = [np.newaxis] * data.ndim
+    bcast_sl[axis] = Ellipsis
+    bcast_sl = tuple(bcast_sl)
+
+    # Median sampling rate
+    fs = 1 / np.median(abs(np.diff(samples)))
+    # Order is sample frequency over cutoff frequency. Ensure order is odd
+    order = int(np.ceil(fs / cutoff) // 2 * 2 + 1)
+    # Make the window. Flattop seems to work well here
+    kernel = signal.firwin(order, cutoff, window="flattop", fs=fs)[bcast_sl]
+
+    # Low-pass filter the visibilities. `oaconvolve` is significantly
+    # faster than the standard convolve method
+    vw_lp = signal.oaconvolve(data * weight, kernel, mode="same")
+    ww_lp = signal.oaconvolve(weight, kernel, mode="same")
+
+    return vw_lp * tools.invert_no_zero(ww_lp)
+
+
+def highpass_weighted_convolution_filter(
+    data: npt.NDArray[np.floating | np.complexfloating],
+    weight: npt.NDArray[np.floating | np.complexfloating],
+    samples: npt.NDArray[np.floating | np.complexfloating],
+    cutoff: float,
+    axis: int = -1,
+) -> np.ndarray[np.floating | np.complexfloating]:
+    """Apply a crude high-pass weighted convolution filter along an axis.
+
+    Filter is applied by subtracting a low-pass filtered version of the data.
+
+    Parameters
+    ----------
+    data
+        The data to filter.
+    weight
+        The weights to apply.
+    samples
+        The sample times.
+    cutoff
+        The cutoff frequency.
+    axis
+        The axis to apply the filter along.
+    """
+    datalp = lowpass_weighted_convolution_filter(
+        data, weight, samples, cutoff, axis=axis
+    )
+
+    return data - datalp
+
+
+def medfilt(
+    x: npt.NDArray[np.floating | np.complexfloating],
+    mask: npt.NDArray[np.bool_],
+    size: tuple[int],
+    *args,
+) -> npt.NDArray[np.floating | np.complexfloating]:
+    """Apply a moving median filter to masked data.
+
+    Parameters
+    ----------
+    x
+        Data to filter.
+    mask
+        Mask of data to filter out.
+    size
+        Size of the window in each dimension.
+    args
+        Additional arguments to pass to the moving weighted median
+
+    Returns
+    -------
+    y
+        The masked data. Data within the mask is undefined.
+    """
+    if np.iscomplexobj(x):
+        return medfilt(x.real, mask, size) + 1.0j * medfilt(x.imag, mask, size)
+
+    # Copy and do initial masking
+    x = np.ascontiguousarray(x.astype(np.float64))
+    w = np.ascontiguousarray((~mask).astype(np.float64))
+
+    return weighted_median.moving_weighted_median(x, w, size, *args)
+
+
+def null_filter(
+    samples: npt.NDArray[np.floating],
+    cutoff: float,
+    mask: npt.NDArray[np.bool_],
+    num_modes: int = 200,
+    tol: float = 1e-8,
+    window: str | bool = True,
+    type_: str = "high",
+    lapack_driver: str = "gesvd",
+) -> np.ndarray[np.floating, 2]:
+    """Create a high-pass or low-pass filter by nulling Fourier modes.
+
+    Parameters
+    ----------
+    samples
+        Samples we have data at.
+    cutoff
+        Fourier inverse cut to apply.
+    mask
+        Samples to mask out.
+    num_modes
+        Number of fourier samples to use in the range -cutoff to +cutoff.
+    tol
+        Cutoff value for singular values.
+    window
+        Apply a window function to the data while filtering.
+    type_
+        Whether to apply a high-pass or low-pass filter. Options are
+        `high` or `low`. Default is `high`.
+    lapack_driver
+        Which lapack driver to use in the SVD. Options are 'gesvd' or 'gesdd'.
+        'gesdd' is generally faster, but seems to experience convergence issues.
+        Default is 'gesvd'.
+
+    Returns
+    -------
+    filter
+        The filter as a 2D matrix.
+    """
+    if type_ not in {"high", "low"}:
+        raise ValueError(f"Filter type must be one of [high, low]. Got {type_}")
+
+    fmodes = np.linspace(-cutoff, cutoff, num_modes)
+
+    # Construct the Fourier matrix
+    F = mask[:, np.newaxis] * np.exp(
+        2.0j * np.pi * fmodes[np.newaxis, :] * samples[:, np.newaxis]
+    )
+
+    if window:
+        # Construct the window function
+        x = (samples - samples.min()) / np.ptp(samples)
+        window = "nuttall" if window is True else window
+        w = window_generalised(x, window=window)
+
+        F *= w[:, np.newaxis]
+
+    # Use an SVD to figure out the set of significant modes spanning the delays
+    # we are wanting to get rid of.
+    # NOTE: we've experienced some convergence failures in here which ultimately seem
+    # to be the fault of MKL (see https://github.com/scipy/scipy/issues/10032 and links
+    # therein). This seems to be limited to the `gesdd` LAPACK routine, so we can get
+    # around it by switching to `gesvd`.
+    u, sig, _ = la.svd(F, full_matrices=False, lapack_driver=lapack_driver)
+    nmodes = np.sum(sig > tol * sig.max())
+    p = u[:, :nmodes]
+
+    # Construct a projection matrix for the filter
+    proj = p @ p.T.conj()
+
+    if type_ == "high":
+        proj = np.identity(samples.size) - proj
+
+    # Multiply in the mask and window (if applicable)
+    proj *= mask[np.newaxis, :]
+
+    if window:
+        proj *= w[np.newaxis, :]
+
+    return proj

--- a/draco/util/tools.py
+++ b/draco/util/tools.py
@@ -340,7 +340,7 @@ def calculate_redundancy(input_flags, prod_map, stack_index, nstack):
         Array indicating the total number of redundant baselines
         with good inputs that were stacked into each unique baseline.
     """
-    ninput, ntime = input_flags.shape
+    _, ntime = input_flags.shape
     redundancy = np.zeros((nstack, ntime), dtype=np.float32)
 
     if not np.any(input_flags):


### PR DESCRIPTION
The Stokes I mask code is a bit messy and the second stage is questionable (although at the moment, there are a handful of narrow RFI bands that don't get caught anywhere else). This PR splits the task into separate tasks, by creating a base `RFIVisMask` task and two derived tasks.

It also creates a new `util.filters` module, and moves some basic filters from elsewhere:
- weighted convolution highpass/lowpass filter
- median filter (basically just calls `caput.moving_weighted_median`, but handles complex data)
- null delay filter (changed to `null_filter`)

It may be helpful to look at the commits individually.

There will be a second PR which is currently based against this branch, but I wanted to split them up.

Also, some `ruff` updates.