### PR TITLE
Static frequency mask estimation from visibility data

### DIFF
--- a/draco/analysis/beamform.py
+++ b/draco/analysis/beamform.py
@@ -1442,7 +1442,6 @@ class HybridVisBeamForm(tasklib.base.ContainerTask):
 
         # Loop over sources and fringestop
         for ss, (idec, sdec) in enumerate(zip(nearest_dec, np.radians(src_dec))):
-
             in_range = np.flatnonzero(valid[ss])
             if (in_range.size == 0) or not valid_src[ss]:
                 continue
@@ -1455,7 +1454,6 @@ class HybridVisBeamForm(tasklib.base.ContainerTask):
             islcs = find_contiguous_slices(in_range)
             count = 0
             for islc in islcs:
-
                 svis = vis[..., idec, islc]  # pol, freq, ew, ha
                 sweight = weight[..., islc]
 
@@ -1468,7 +1466,6 @@ class HybridVisBeamForm(tasklib.base.ContainerTask):
 
                 # Loop over local frequencies and fringestop
                 for ff in range(svis.shape[1]):
-
                     owe[ss, :, ff, :, oslc] = sweight[:, ff]
 
                     # Calculate the phase
@@ -1578,7 +1575,6 @@ class FitBeamFormed(BeamFormExternalMixin, tasklib.base.ContainerTask):
 
         # Loop over sources
         for ss, sdec in enumerate(src_dec):
-
             # Ignore missing sources
             if not np.any(weight[ss] > 0.0):
                 continue
@@ -1590,7 +1586,6 @@ class FitBeamFormed(BeamFormExternalMixin, tasklib.base.ContainerTask):
 
             # Loop over polarisation
             for pp, pol in enumerate(data.pol):
-
                 b = beam[ss, pp, ..., slc]
                 w = weight[ss, pp, ..., slc]
 

--- a/draco/analysis/dayenu.py
+++ b/draco/analysis/dayenu.py
@@ -500,14 +500,12 @@ class DayenuDelayFilterHybridVis(tasklib.base.ContainerTask):
 
         # Loop over products
         for tt in range(ntime):
-
             t0 = time.time()
 
             flag = weight[..., tt] > 0.0
             flag = np.all(flag, axis=0, keepdims=True)
 
             for xx in range(new):
-
                 self.log.debug(f"Filter time {tt} of {ntime}, baseline {xx} of {new}.")
 
                 flagx = flag[0, :, xx, np.newaxis]
@@ -534,7 +532,6 @@ class DayenuDelayFilterHybridVis(tasklib.base.ContainerTask):
 
                 # Apply the filter
                 for pp in range(npol):
-
                     # Save the filter to the container
                     if self.save_filter:
                         filt[pp, :, :, xx, tt] = NF[0]
@@ -670,9 +667,7 @@ class ApplyDelayFilterHybridVis(tasklib.base.ContainerTask):
             self.log.debug(f"Filter time {tt} of {ntime}.")
 
             for xx in range(new):
-
                 for pp in range(npol):
-
                     flag = weight[pp, :, xx, tt] > 0.0
 
                     # Skip fully masked samples
@@ -1186,7 +1181,6 @@ def delay_filter(freq, flag, tau_width, tau_centre=0.0, epsilon=1e-12):
 
     cov = np.eye(nfreq, dtype=dtype)
     for tw, tc, eps in zip(*args):
-
         term = np.sinc(2.0 * tw * dfreq) / eps
         if np.abs(tc) > 0.0:
             term = term * np.exp(-2.0j * np.pi * tc * dfreq)

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -1252,10 +1252,10 @@ class RFITransientVisMask(RFIVisMask):
                 hpf_cut,
                 axis=-1,
             )
-            cfft.fft(vhpf, axis=0, out=vhpf)
-            np.absolute(vhpf, out=vhpf)
+            vfft = cfft.fft(vhpf, axis=0)
+            np.absolute(vfft, out=vfft)
             # Compute median absolute deviations of the filtered map
-            mad_ = mad(vhpf, fl[ii], self.mad_base_size, self.mad_dev_size)
+            mad_ = mad(vfft, fl[ii], self.mad_base_size, self.mad_dev_size)
             # Hysteresis threshold mask flags anything above `sigma_high` or
             # anything above `sigma_low` ONLY if it is connected to a region
             # above `sigma_high`

--- a/draco/analysis/flagging.py
+++ b/draco/analysis/flagging.py
@@ -192,6 +192,9 @@ class MaskBaselines(tasklib.base.ContainerTask):
     mask_short_ns : float, optional
         Mask out baselines shorter then a given distance in the North-South
         direction.
+    mask_pol : list of str, optional
+        List of polarisation products to mask. Each entry should be a string
+        of length 2, e.g. ["XX", "YY"].
     missing_threshold : float, optional
         Mask any baseline that is missing more than this fraction of samples. This is
         measured relative to other baselines.
@@ -213,6 +216,8 @@ class MaskBaselines(tasklib.base.ContainerTask):
     mask_short = config.Property(proptype=float, default=None)
     mask_short_ew = config.Property(proptype=float, default=None)
     mask_short_ns = config.Property(proptype=float, default=None)
+
+    mask_pol = config.Property(proptype=list, default=None)
 
     weight_threshold = config.Property(proptype=float, default=None)
     missing_threshold = config.Property(proptype=float, default=None)
@@ -305,6 +310,15 @@ class MaskBaselines(tasklib.base.ContainerTask):
                 > self.missing_threshold,
                 out=mask,
             )
+
+        if self.mask_pol is not None:
+            pols = np.char.array(self.telescope.polarisation)[
+                self.telescope.uniquepairs
+            ]
+            pols = pols[:, 0] + pols[:, 1]
+
+            for p in self.mask_pol:
+                combine_func(mask, (pols == p)[np.newaxis, :, np.newaxis], out=mask)
 
         if self.share == "all":
             ssc = ss

--- a/draco/analysis/fringestop.py
+++ b/draco/analysis/fringestop.py
@@ -113,7 +113,6 @@ class Mix(tasklib.base.ContainerTask):
 
         # Loop over local frequencies
         for ff, nu in enumerate(freq):
-
             lmbda = scipy.constants.c / (nu * 1e6)
 
             omega = 2.0 * np.pi * x * cos_dec / lmbda

--- a/draco/analysis/hyforesbandpass.py
+++ b/draco/analysis/hyforesbandpass.py
@@ -141,9 +141,7 @@ class DelayFilterHyFoReSBandpassHybridVis(tasklib.base.ContainerTask):
 
             # new stands for number east-west
             for xx in range(new):
-
                 for pp in range(npol):
-
                     flag = weight[pp, :, xx, tt] > 0.0
 
                     if not np.any(flag):
@@ -212,9 +210,7 @@ class DelayFilterHyFoReSBandpassHybridVis(tasklib.base.ContainerTask):
         self.log.debug("Start computing the estimated gains.")
         t0 = time.time()
         for pp in range(npol):
-
             for ff in range(nfreq):
-
                 for xx in range(new):
                     # grab datasets
                     # original data
@@ -253,7 +249,6 @@ class DelayFilterHyFoReSBandpassHybridVis(tasklib.base.ContainerTask):
         self.log.debug("Start computing the window.")
         t0 = time.time()
         for pp in range(npol):
-
             for xx in range(new):
                 for tt in range(ntime):
                     # grab datasets
@@ -423,9 +418,7 @@ class DelayFilterHyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVi
 
             # new stands for number east-west
             for xx in range(new):
-
                 for pp in range(npol):
-
                     flag = weight[pp, :, xx, tt] > 0.0
 
                     if not np.any(flag):
@@ -498,9 +491,7 @@ class DelayFilterHyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVi
         self.log.debug("Start computing the estimated gains.")
         t0 = time.time()
         for pp in range(npol):
-
             for ff in range(nfreq):
-
                 for xx in range(new):
                     # grab datasets
                     tvis = np.ascontiguousarray(vis[pp, ff, xx, ...])  # original data
@@ -658,9 +649,7 @@ class HyFoReSBandpassHybridVis(DelayFilterHyFoReSBandpassHybridVis):
         self.log.debug("Start computing the estimated gains.")
         t0 = time.time()
         for pp in range(npol):
-
             for ff in range(nfreq):
-
                 for xx in range(new):
                     # grab datasets
                     tvis = np.ascontiguousarray(vis[pp, ff, xx, ...])  # original data
@@ -830,7 +819,6 @@ class HyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVis):
         for pp in range(npol):
             # step 2
             for ff in range(nfreq):
-
                 for xx in range(new):
                     # grab datasets
                     tvis = np.ascontiguousarray(vis[pp, ff, xx, ...])  # original data
@@ -868,7 +856,6 @@ class HyFoReSBandpassHybridVisMask(DelayFilterHyFoReSBandpassHybridVis):
         self.log.debug("Start computing the window.")
         t0 = time.time()
         for pp in range(npol):
-
             for xx in range(new):
                 for tt in range(ntime):
                     # grab datasets
@@ -1008,9 +995,7 @@ class HyFoReSBandpassHybridVisMaskKeepSource(DelayFilterHyFoReSBandpassHybridVis
         self.log.debug("Start computing the estimated gains.")
         t0 = time.time()
         for pp in range(npol):
-
             for ff in range(nfreq):
-
                 for xx in range(new):
                     # grab datasets
                     tvis = np.ascontiguousarray(vis[pp, ff, xx, ...])  # original data
@@ -1048,7 +1033,6 @@ class HyFoReSBandpassHybridVisMaskKeepSource(DelayFilterHyFoReSBandpassHybridVis
         self.log.debug("Start computing the window.")
         t0 = time.time()
         for pp in range(npol):
-
             for xx in range(new):
                 for tt in range(ntime):
                     # grab datasets
@@ -1200,13 +1184,10 @@ class DelayFilterHyFoReSBandpassHybridVisClean(tasklib.base.ContainerTask):
             g = y
             self.log.debug("Skip compensating the window")
         else:
-
             self.log.debug("Start compensating the window")
 
             for pp in range(npol):
-
                 for xx in range(new):
-
                     # save the singular values for debugging or inspection
                     s_val[pp, xx] = la.svd(W[pp, xx, :, :], compute_uv=False)
                     # TODO: use la.solve(W, y)
@@ -1243,9 +1224,7 @@ class DelayFilterHyFoReSBandpassHybridVisClean(tasklib.base.ContainerTask):
             self.log.debug(f"Filter time {tt} of {ntime}.")
 
             for xx in range(new):
-
                 for pp in range(npol):
-
                     flag = weight[pp, :, xx, tt] > 0.0
 
                     if not np.any(flag):

--- a/draco/analysis/interpolate.py
+++ b/draco/analysis/interpolate.py
@@ -250,7 +250,7 @@ class DPSSFilterBaseline(DPSSFilter):
 
         for ii, cut in enumerate(cuts):
             self.log.debug(
-                f"Making unique covariance {ii+1}/{len(cuts)} with cut={cut}."
+                f"Making unique covariance {ii + 1}/{len(cuts)} with cut={cut}."
             )
             cov = dpss.make_covariance(samples, cut, 0.0)
             modes.append(dpss.get_basis(cov))
@@ -380,8 +380,7 @@ def _flatten_axes(data, axes):
 
     if not axind:
         raise ValueError(
-            f"No matching axes. Dataset has axes {dax}, "
-            f"but axes {axes} were requested."
+            f"No matching axes. Dataset has axes {dax}, but axes {axes} were requested."
         )
 
     ds = data[:].view(np.ndarray)

--- a/draco/analysis/powerspec.py
+++ b/draco/analysis/powerspec.py
@@ -104,7 +104,6 @@ class TransformJyPerBeamToKelvin(tasklib.base.ContainerTask):
         return out_map
 
     def _get_max_baseline(self):
-
         prod = self.telescope.prodstack
         baselines = (
             self.telescope.feedpositions[prod["input_a"], :]
@@ -243,7 +242,6 @@ class ConstructWienerDelayTransform(tasklib.base.ContainerTask):
 
         # Loop over polarisations
         for pp in range(npol):
-
             self.log.info(f"Polarisation {pp} of {npol}")
 
             # The filter and freq_cov datasets do not have an elevation axis.
@@ -258,7 +256,6 @@ class ConstructWienerDelayTransform(tasklib.base.ContainerTask):
 
             # Loop over elevations
             for ee in range(nel_local):
-
                 self.log.info(f"Elevation {ee} of {nel_local}")
 
                 # Extract maps for this polarisation and elevation
@@ -438,11 +435,9 @@ class ApplyWienerDelayTransform(tasklib.base.ContainerTask):
 
         # Loop over pol and ra
         for pp in range(npol):
-
             eslc = slice(pp * nel, (pp + 1) * nel)
 
             for rr in range(nra):
-
                 # Shape (el, delay, freq)
                 op = filt[pp, rr]
 
@@ -744,8 +739,7 @@ class CrossPowerSpectrum3D(tasklib.base.ContainerTask):
         # Validate the types are the same
         if type(vis_1) is not type(vis_2):
             raise TypeError(
-                f"type(vis_1) (={type(vis_1)}) must match "
-                f"type(vis_2) (={type(vis_2)})"
+                f"type(vis_1) (={type(vis_1)}) must match type(vis_2) (={type(vis_2)})"
             )
 
         vis_1.redistribute("delay")
@@ -813,7 +807,7 @@ class CrossPowerSpectrum3D(tasklib.base.ContainerTask):
             pid_2 = pol_2.index(pstr_2)
 
             self.log.debug(
-                "Estimating power spectrum for pol: " f"{pstr} ({pid_1} x {pid_2})"
+                f"Estimating power spectrum for pol: {pstr} ({pid_1} x {pid_2})"
             )
 
             pspec[pp] = ps_norm * (vis_1[pid_1] * vis_2[pid_2].conj())

--- a/draco/analysis/ringmapmaker.py
+++ b/draco/analysis/ringmapmaker.py
@@ -288,7 +288,7 @@ class BeamformNS(tasklib.base.ContainerTask):
         hv.attrs["beamform_ns_nsmax"] = nsmax
 
         # choose the precision which will be used in `matmul`
-        complex_dtype = np.dtype(f"complex{2*self.precision:.0f}")
+        complex_dtype = np.dtype(f"complex{2 * self.precision:.0f}")
         real_dtype = np.dtype(f"float{self.precision:.0f}")
 
         # precompute a phase array
@@ -504,8 +504,7 @@ class BeamformEW(tasklib.base.ContainerTask):
         if ("XY" in pols) or ("YX" in pols):
             if ("XY" in pols) ^ ("YX" in pols):
                 raise ValueError(
-                    "If cross-pols exist, both XY and YX must be present. "
-                    f"Got {pols}."
+                    f"If cross-pols exist, both XY and YX must be present. Got {pols}."
                 )
             dpol = ["reXY", "imXY"]
         else:

--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -2013,7 +2013,9 @@ class ReduceBase(tasklib.base.ContainerTask):
 
         return out
 
-    def _get_weights(self, data: containers.ContainerBase) -> mpiarray.MPIArray | None:
+    def _get_weights(
+        self, data: ContainerPrototype
+    ) -> tuple[mpiarray.MPIArray | None, list | None]:
         """Get the weights to use for the reduction."""
         if not hasattr(data, "weight") and self.weighting != "none":
             raise RuntimeError(
@@ -2025,9 +2027,7 @@ class ReduceBase(tasklib.base.ContainerTask):
 
         return None, None
 
-    def _make_output_container(
-        self, data: containers.ContainerBase
-    ) -> containers.ContainerBase:
+    def _make_output_container(self, data: ContainerPrototype) -> ContainerPrototype:
         """Create the output container."""
         # For a collapsed axis, the meaning of the index map will depend on
         # the reduction being done, and can be meaningless. The first value

--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1318,9 +1318,7 @@ class FilterFreqContainer(ContainerPrototype):
     _axes = ("freq_sum",)
 
     def __init__(self, *args, **kwargs):
-
         for ax in ["freq_sum"]:
-
             if ax not in kwargs:
                 if "axes_from" in kwargs and ax in kwargs["axes_from"].index_map:
                     kwargs[ax] = kwargs["axes_from"].index_map[ax]

--- a/draco/synthesis/noise.py
+++ b/draco/synthesis/noise.py
@@ -432,9 +432,7 @@ class FreqCorrelatedNoise(tasklib.base.ContainerTask, tasklib.random.RandomTask)
 
         # Loop over pol and ew to reduce memory usage
         for pp in range(npol):
-
             for ee in range(new):
-
                 # Generate a set of complex random numbers with unit standard deviation
                 z = np.empty((nra, nfreq, nns), dtype=ovis.dtype)
 

--- a/draco/util/filters.py
+++ b/draco/util/filters.py
@@ -58,7 +58,11 @@ def lowpass_weighted_convolution_filter(
     vw_lp = signal.oaconvolve(data * weight, kernel, mode="same")
     ww_lp = signal.oaconvolve(weight, kernel, mode="same")
 
-    return vw_lp * algorithms.invert_no_zero(ww_lp)
+    # Avoid some extra copies
+    ww_lp = algorithms.invert_no_zero(ww_lp, out=ww_lp)
+    vw_lp *= ww_lp
+
+    return vw_lp
 
 
 def highpass_weighted_convolution_filter(

--- a/draco/util/kernels.py
+++ b/draco/util/kernels.py
@@ -51,7 +51,7 @@ def get_kernel(name: str, **kernel_params):
 
     if kernelfunc is None:
         raise ValueError(
-            f"Invalid kernel type: '{name}'. " f"Valid kernels: {list(kdict.keys())}"
+            f"Invalid kernel type: '{name}'. Valid kernels: {list(kdict.keys())}"
         )
 
     return kernelfunc(**kernel_params)
@@ -258,7 +258,6 @@ def moving_average_inverse_kernel(
     # Calculate the matrix for the moving average
     W = np.zeros((N, N))
     for i in range(N):
-
         ll, ul = i - (width - 1) // 2, i + (width + 1) // 2
         if not periodic:
             ll, ul = max(0, ll), min(ul, N)

--- a/draco/util/regrid.py
+++ b/draco/util/regrid.py
@@ -194,7 +194,6 @@ def rebin_matrix(tra: np.ndarray, ra: np.ndarray, width_t: float = 0) -> np.ndar
     # NOTE: this can probably be done more efficiently, but we typically only need
     # to do this once per day
     for ii, (jj, t) in enumerate(zip(inds, tra)):
-
         lower_edge = t - width_t / 2.0
         upper_edge = t + width_t / 2.0
 

--- a/draco/util/rfi.py
+++ b/draco/util/rfi.py
@@ -1,6 +1,7 @@
 """Collection of routines for RFI excision."""
 
 import numpy as np
+import numpy.typing as npt
 from scipy.ndimage import correlate1d
 
 
@@ -143,43 +144,125 @@ def sumthreshold_py(
 sumthreshold = sumthreshold_py
 
 
-# Scale-invariant rank (SIR) functions
-def sir1d(basemask, eta=0.2):
+def _sir_lastaxis(
+    basemask: npt.NDArray[np.bool_], eta: float = 0.2, axis=-1
+) -> npt.NDArray[np.bool]:
     """Numpy implementation of the scale-invariant rank (SIR) operator.
 
     For more information, see arXiv:1201.3364v2.
 
     Parameters
     ----------
-    basemask : numpy 1D array of boolean type
+    basemask
         Array with the threshold mask previously generated.
         1 (True) for flagged points, 0 (False) otherwise.
-    eta : float
+    eta
         Aggressiveness of the method: with eta=0, no additional samples are
         flagged and the function returns basemask. With eta=1, all samples
         will be flagged. The authors in arXiv:1201.3364v2 seem to be convinced
         that 0.2 is a mostly universally optimal value, but no optimization
         has been done on CHIME data.
+    axis
+        Axis along which to apply the SIR operator. Default is -1,
+        which applies it along the last axis.
 
     Returns
     -------
-    mask : numpy 1D array of boolean type
+    mask
         The mask after the application of the (SIR) operator. Same shape and
         type as basemask.
     """
-    n = basemask.size
-    psi = basemask.astype(np.float64) - 1.0 + eta
+    # Move the filtetr axis to the end and copy to ensure contiguous array
+    basemask = np.moveaxis(basemask, axis, -1).copy()
 
-    M = np.zeros(n + 1, dtype=np.float64)
-    M[1:] = np.cumsum(psi)
+    M = np.zeros((*basemask.shape[:-1], basemask.shape[-1] + 1), dtype=np.float64)
+    # Copy the basemask into the appropriate slice of M,
+    # which will automatically cast to float64. Use `M` to
+    # avoid an additional allocation
+    M[..., 1:] = basemask
+    M[..., 1:] += eta - 1.0
 
-    MP = np.minimum.accumulate(M)[:-1]
-    MQ = np.concatenate((np.maximum.accumulate(M[-2::-1])[-2::-1], M[-1, np.newaxis]))
+    # cumulative sum stored directly into `M` to avoid
+    # an additional allocation
+    # NOTE: neither `cumsum` not `accumulate` seem to use
+    # multiple threads, so this seems like a fairly easy place
+    # for significant performance improvement
+    np.cumsum(M[..., 1:], axis=-1, out=M[..., 1:])
 
-    return (MQ - MP) >= 0.0
+    MP = np.minimum.accumulate(M, axis=-1)[..., :-1]
+    # Re-use `M` again
+    np.maximum.accumulate(M[..., -2::-1], axis=-1, out=M[..., -2::-1])
+
+    basemask |= M[..., 1:] >= MP
+
+    return np.moveaxis(basemask, -1, axis)
 
 
-def sir(basemask, eta=0.2, only_freq=False, only_time=False):
+# Alias for backward compatibility
+sir1d = _sir_lastaxis
+
+
+def scale_invariant_rank(
+    basemask: npt.NDArray[np.bool_],
+    eta: float | tuple[float, ...] = 0.2,
+    axis: int | tuple[int, ...] = -1,
+) -> npt.NDArray[np.bool]:
+    """Apply the scale-invariant rank (SIR) operator along one or more axes.
+
+    This is a wrapper for `sir1d`.  It loops over the provided axes, applying
+    `sir1d` along each axis in turn.  It returns the logical OR of these masks.
+
+    Parameters
+    ----------
+    basemask
+        The previously generated threshold mask.
+        1 (True) for masked points, 0 (False) otherwise.
+    eta
+        Aggressiveness of the method: with eta=0, no additional samples are
+        flagged and the function returns basemask. With eta=1, all samples
+        will be flagged. If a tuple is provided, it must have the same length
+        as `axis`, and the corresponding value will be used for each axis.
+    axis
+        Axis or axes along which to apply the SIR operator. Default is -1,
+        which applies it along the last axis.
+
+    Returns
+    -------
+    mask
+        The mask after the application of the SIR operator.
+    """
+    if basemask.ndim < 1:
+        raise ValueError("basemask must have at least one dimension.")
+
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    if isinstance(eta, float | int):
+        eta = (eta,) * len(axis)
+
+    if len(eta) != len(axis):
+        raise ValueError(
+            "If eta is a tuple, it must have the same length as axis."
+            f"Got len(eta)={len(eta)} and len(axis)={len(axis)}."
+        )
+
+    # Avoids an unnecessary copy in the case where only one axis is requested
+    newmask = _sir_lastaxis(basemask, eta=eta[0], axis=axis[0])
+
+    # Iterate over the axes, applying sir1d to the
+    # base mask along each axis
+    for ax, et in zip(axis[1:], eta[1:]):
+        newmask |= _sir_lastaxis(basemask, eta=et, axis=ax)
+
+    return newmask
+
+
+def sir(
+    basemask: npt.NDArray[np.bool_],
+    eta: float = 0.2,
+    only_freq: bool = False,
+    only_time: bool = False,
+) -> npt.NDArray[np.bool]:
     """Apply the SIR operator over the frequency and time axes for each product.
 
     This is a wrapper for `sir1d`.  It loops over times, applying `sir1d`
@@ -188,23 +271,37 @@ def sir(basemask, eta=0.2, only_freq=False, only_time=False):
 
     Parameters
     ----------
-    basemask : np.ndarray[nfreq, nprod, ntime] of boolean type
+    basemask
         The previously generated threshold mask.
         1 (True) for masked points, 0 (False) otherwise.
-    eta : float
+    eta
         Aggressiveness of the method: with eta=0, no additional samples are
         flagged and the function returns basemask. With eta=1, all samples
         will be flagged.
-    only_freq : bool
+    only_freq
         Only apply the SIR operator across the frequency axis.
-    only_time : bool
+    only_time
         Only apply the SIR operator across the time axis.
 
     Returns
     -------
-    mask : np.ndarray[nfreq, nprod, ntime] of boolean type
+    mask
         The mask after the application of the SIR operator.
     """
+    import warnings
+
+    warnings.warn(
+        "The sir function is deprecated and will be removed in a future release. "
+        "Please use the updated `scale_invariant_rank` function with `axis=(0, -1)`.",
+        DeprecationWarning,
+    )
+
+    if basemask.ndim != 3:
+        raise ValueError(
+            "basemask must be a 3D array with [freq, prod, time] axes. "
+            f"Got {basemask.ndim}D array instead."
+        )
+
     if only_freq and only_time:
         raise ValueError("Only one of only_freq and only_time can be True.")
 
@@ -215,10 +312,10 @@ def sir(basemask, eta=0.2, only_freq=False, only_time=False):
     for pp in range(nprod):
         if not only_time:
             for tt in range(ntime):
-                newmask[:, pp, tt] |= sir1d(basemask[:, pp, tt], eta=eta)
+                newmask[:, pp, tt] |= _sir_lastaxis(basemask[:, pp, tt], eta=eta)
 
         if not only_freq:
             for ff in range(nfreq):
-                newmask[ff, pp, :] |= sir1d(basemask[ff, pp, :], eta=eta)
+                newmask[ff, pp, :] |= _sir_lastaxis(basemask[ff, pp, :], eta=eta)
 
     return newmask


### PR DESCRIPTION
The overall goal of this PR is to implement a task to come up with a static RFI mask from visibility data directly, without having to rely on a hard-coded set of bad channels.

This produces a flagging metric by reducing over baselines using the existing `ReduceChisq` code as follows:
- The chi2 is computed over cross-pol baselines only, and excludes baselines < 5 meters.
- Weighting is done by dividing by baseline redundancy (effectively up-weighting baselines with lower redundancy), which highlights faint frequency bands which are only otherwise visible in the high-delay chisq metric.

Flagging is then done using a simple 1D MAD metric over the 1D median in time of the chisq metric. Only nighttime data is included in the median (the hook is implemented in a `ch_pipeline` PR). It uses an updated version of the `arPLS` baseline-fitting code, which is better able to handle the lack of hard-coded static mask.

This PR does the following:
- Updated the `scale_invariant_rank` operation to be a bit faster
- Adds options to the `MaskBaselines` task to mask polarisation and to optionally combine the mask using an `and` operation
- Extends the `ReduceBase` task with a hook for custom weights
- Updates the `penalized_least_squares` implementation to support different weighting schemes
- Replaces the old narrowband vis flagging task with this new static RFI mask task

This code all works and is tested. This method does not appear to overflag, although there is absolutely room for improvement.