### PR TITLE
Update compression arguments and chunking for TimeStream container

### DIFF
--- a/draco/core/containers.py
+++ b/draco/core/containers.py
@@ -1467,7 +1467,7 @@ class TimeStream(FreqContainer, VisContainer, TODContainer):
             "distributed_axis": "freq",
             "compression": COMPRESSION,
             "compression_opts": COMPRESSION_OPTS,
-            "chunks": (64, 128, 128),
+            "chunks": (16, 256, 1024),
             "truncate": {
                 "weight_dataset": "vis_weight",
             },
@@ -1480,7 +1480,7 @@ class TimeStream(FreqContainer, VisContainer, TODContainer):
             "distributed_axis": "freq",
             "compression": COMPRESSION,
             "compression_opts": COMPRESSION_OPTS,
-            "chunks": (64, 128, 128),
+            "chunks": (16, 256, 1024),
             "truncate": True,
         },
         "input_flags": {
@@ -1495,6 +1495,9 @@ class TimeStream(FreqContainer, VisContainer, TODContainer):
             "initialise": False,
             "distributed": True,
             "distributed_axis": "freq",
+            "compression": COMPRESSION,
+            "compression_opts": COMPRESSION_OPTS,
+            "chunks": (16, 256, 1024),
         },
     }
 


### PR DESCRIPTION
- Increase total chunk size and reduce number of frequencies per chunk (since this is out typically access slice axis)
- Add compression to the `gain` dataset