### PR TITLE
Fix invalid default for 'aux_coeff' property

### DIFF
--- a/draco/analysis/transform.py
+++ b/draco/analysis/transform.py
@@ -1644,7 +1644,7 @@ class MixData(task.SingleTask):
     data_coeff = config.list_type(type_=float)
     weight_coeff = config.list_type(type_=float)
     tag_coeff = config.list_type(type_=bool)
-    aux_coeff = config.Property(proptype=dict)
+    aux_coeff = config.Property(proptype=dict, default={})
     invert_weight = config.Property(proptype=bool, default=False)
     require_nonzero_weight = config.Property(proptype=bool, default=False)
 


### PR DESCRIPTION
With no default set, this would get set to `None` if not provided. However, the task tries to iterate over items in the property, which fails if it's `None`. Use an empty dictionary as default instead.